### PR TITLE
Fix | "root_path" to be absolute from parameter or cwd

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,6 +62,11 @@ impl TryFrom<Cli> for Config {
 
     fn try_from(cli_aguments: Cli) -> Result<Self, Self::Error> {
         let verbose = cli_aguments.verbose;
+        let root_dir = if cli_aguments.root_dir.to_str().unwrap() == "./" {
+            current_dir().unwrap()
+        } else {
+            cli_aguments.root_dir.canonicalize().unwrap()
+        };
 
         let tls: Option<tls::TlsConfig> = if cli_aguments.tls {
             Some(tls::TlsConfig::new(
@@ -77,7 +82,7 @@ impl TryFrom<Cli> for Config {
             host: cli_aguments.host,
             port: cli_aguments.port,
             address: SocketAddr::new(cli_aguments.host, cli_aguments.port),
-            root_dir: cli_aguments.root_dir,
+            root_dir,
             verbose,
             tls,
         })

--- a/src/server/service/file_explorer.rs
+++ b/src/server/service/file_explorer.rs
@@ -9,7 +9,7 @@ use hyper_staticfile::{resolve, ResolveResult, ResponseBuilder as FileResponseBu
 use serde::Serialize;
 use std::cmp::{Ord, Ordering};
 use std::fs::read_dir;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -234,7 +234,7 @@ impl<'a> FileExplorer<'a> {
                     .to_string(),
                 is_dir: metadata.is_dir(),
                 size: FileExplorer::format_bytes(metadata.len() as f64),
-                entry_path: FileExplorer::make_dir_entry_link(&root_dir, entry.path()),
+                entry_path: FileExplorer::make_dir_entry_link(&root_dir, &entry.path()),
                 created_at,
                 updated_at,
             });
@@ -281,12 +281,12 @@ impl<'a> FileExplorer<'a> {
     ///
     /// This happens because links should behave relative to the `/` path
     /// which in this case is `http-server/src` instead of system's root path.
-    fn make_dir_entry_link(root_dir: &PathBuf, entry_path: PathBuf) -> String {
+    fn make_dir_entry_link(root_dir: &Path, entry_path: &Path) -> String {
         // format!("/{}", &entry_path[current_dir_path.len()..])
         let root_dir = root_dir.to_str().unwrap();
         let entry_path = entry_path.to_str().unwrap();
-
-        entry_path[root_dir.len() - 1..].to_string()
+        println!("{}\n{}", root_dir, entry_path);
+        entry_path[root_dir.len()..].to_string()
     }
 
     /// Calculates the format of the `Bytes` by converting `bytes` to the
@@ -349,7 +349,7 @@ mod tests {
 
         assert_eq!(
             "/src/server/service/file_explorer.rs",
-            FileExplorer::make_dir_entry_link(&root_dir, entry_path)
+            FileExplorer::make_dir_entry_link(&root_dir, &entry_path)
         );
     }
 }


### PR DESCRIPTION
Currently the root_path is taken as is from the CLI
arguments. If the user provides "./" then, FileExplorer's
entry paths will be created from this path instead of
the absolute path that "./" really represents in user's
system.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
