### PR TITLE
Fix | Binary name to be "http-server" instead of "main"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "http-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-server"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 edition = "2018"
 description = "Simple and configurable command-line HTTP server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,14 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+name = "http_server_lib"
+path = "src/lib.rs"
+
+[[bin]]
+name = "http-server"
+path = "src/bin/main.rs"
+
 [dependencies]
 anyhow = "1"
 async-stream = "0.3"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-use http_server::make_server;
+use http_server_lib::make_server;
 use std::process::exit;
 
 #[tokio::main]


### PR DESCRIPTION
Resolves issue #11 where running `cargo install http-server` installs the binary crate with name `main` instead of `http-server`

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
