### PR TITLE
Refactor | Add-on implementation, Scoped File System and File Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 <Empty>
 
+<a name="v0.3.3"></a>
+## v0.3.3 (2021-06-10)
+
+> Requires Rust: rustc 1.52.1 (9bc8c42bb 2021-05-09)
+
+#### Improvements
+
+* Implement static file serving addon
+
+Introduce the Addon concept to write application logic out of the
+server implementation itself and aim to a modularized architecture.
+
+Implements a static file serving addon to support sending files to
+the client. The static file serving addon also provides a scoped
+file system abstraction which securely resolve files in the file system
+tree.
+
 <a name="v0.3.2"></a>
 ## v0.3.2 (2021-06-08)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "http-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,16 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
-dependencies = [
- "matches",
- "percent-encoding",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,7 +313,7 @@ dependencies = [
  "handlebars",
  "http",
  "hyper",
- "hyper-staticfile",
+ "mime_guess",
  "rustls",
  "serde",
  "structopt",
@@ -368,34 +358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-staticfile"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf435f95723ba94d2e44991abf717dd547b73f505830a917dc442a9195df06b"
-dependencies = [
- "chrono",
- "futures-util",
- "http",
- "hyper",
- "mime_guess",
- "percent-encoding",
- "tokio",
- "url",
- "winapi",
-]
-
-[[package]]
-name = "idna"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,12 +398,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
@@ -536,12 +492,6 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
@@ -844,21 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
 name = "tokio"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,24 +892,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-dependencies = [
- "matches",
-]
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,18 +914,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "url"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
-dependencies = [
- "form_urlencoded",
- "idna",
- "matches",
- "percent-encoding",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ chrono = "0.4"
 futures = "0.3"
 http = "0.2"
 handlebars = "3"
-hyper = { version = "0.14", features = ["http1", "server", "tcp"] }
-hyper-staticfile = "0.6"
+hyper = { version = "0.14", features = ["http1", "server", "stream", "tcp"] }
+mime_guess = "2"
 rustls = "0.19"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["fs", "rt-multi-thread", "macros"] }
 tokio-rustls = "0.22"
 toml = "0.5"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-server"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 edition = "2018"
 description = "Simple and configurable command-line HTTP server"

--- a/src/addon/mod.rs
+++ b/src/addon/mod.rs
@@ -1,0 +1,1 @@
+pub mod static_file;

--- a/src/addon/static_file/file.rs
+++ b/src/addon/static_file/file.rs
@@ -1,0 +1,42 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Local};
+use mime_guess::{from_path, Mime};
+use std::fs::Metadata;
+use std::path::PathBuf;
+
+/// Wrapper around `tokio::fs::File` built from a OS ScopedFileSystem file
+/// providing `std::fs::Metadata` and the path to such file
+#[derive(Debug)]
+pub struct File {
+    pub path: PathBuf,
+    pub file: tokio::fs::File,
+    pub metadata: Metadata,
+}
+
+impl File {
+    pub fn new(path: PathBuf, file: tokio::fs::File, metadata: Metadata) -> Self {
+        File {
+            path,
+            file,
+            metadata,
+        }
+    }
+
+    pub fn mime(&self) -> Mime {
+        from_path(self.path.clone()).first_or_octet_stream()
+    }
+
+    pub fn size(&self) -> u64 {
+        self.metadata.len()
+    }
+
+    pub fn last_modified(&self) -> Result<DateTime<Local>> {
+        let modified = self
+            .metadata
+            .modified()
+            .context("Failed to read last modified time for file")?;
+        let modified: DateTime<Local> = modified.into();
+
+        Ok(modified)
+    }
+}

--- a/src/addon/static_file/http.rs
+++ b/src/addon/static_file/http.rs
@@ -1,0 +1,169 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Local, Utc};
+use futures::Stream;
+use http::response::Builder as HttpResponseBuilder;
+use hyper::body::Body;
+use hyper::body::Bytes;
+use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::task::{self, Poll};
+use tokio::io::{AsyncRead, ReadBuf};
+
+use super::file::File;
+
+const FILE_BUFFER_SIZE: usize = 8 * 1024;
+
+pub type FileBuffer = Box<[MaybeUninit<u8>; FILE_BUFFER_SIZE]>;
+
+/// HTTP Response `Cache-Control` directive
+///
+/// Allow dead code until we have support for cache control configuration
+#[allow(dead_code)]
+
+pub enum CacheControlDirective {
+    /// Cache-Control: must-revalidate
+    MustRevalidate,
+    /// Cache-Control: no-cache
+    NoCache,
+    /// Cache-Control: no-store
+    NoStore,
+    /// Cache-Control: no-transform
+    NoTransform,
+    /// Cache-Control: public
+    Public,
+    /// Cache-Control: private
+    Private,
+    /// Cache-Control: proxy-revalidate
+    ProxyRavalidate,
+    /// Cache-Control: max-age=<seconds>
+    MaxAge(u64),
+    /// Cache-Control: s-maxage=<seconds>
+    SMaxAge(u64),
+}
+
+impl ToString for CacheControlDirective {
+    fn to_string(&self) -> String {
+        match &self {
+            Self::MustRevalidate => String::from("must-revalidate"),
+            Self::NoCache => String::from("no-cache"),
+            Self::NoStore => String::from("no-store"),
+            Self::NoTransform => String::from("no-transform"),
+            Self::Public => String::from("public"),
+            Self::Private => String::from("private"),
+            Self::ProxyRavalidate => String::from("proxy-revalidate"),
+            Self::MaxAge(age) => format!("max-age={}", age),
+            Self::SMaxAge(age) => format!("s-maxage={}", age),
+        }
+    }
+}
+
+pub struct ResponseHeaders {
+    cache_control: String,
+    content_length: u64,
+    content_type: String,
+    etag: String,
+    last_modified: String,
+}
+
+impl ResponseHeaders {
+    pub fn new(
+        file: &File,
+        cache_control_directive: CacheControlDirective,
+    ) -> Result<ResponseHeaders> {
+        let last_modified = file.last_modified()?;
+
+        Ok(ResponseHeaders {
+            cache_control: cache_control_directive.to_string(),
+            content_length: ResponseHeaders::content_length(file),
+            content_type: ResponseHeaders::content_type(file),
+            etag: ResponseHeaders::etag(file, &last_modified),
+            last_modified: ResponseHeaders::last_modified(&last_modified),
+        })
+    }
+
+    fn content_length(file: &File) -> u64 {
+        file.size()
+    }
+
+    fn content_type(file: &File) -> String {
+        file.mime().to_string()
+    }
+
+    fn etag(file: &File, last_modified: &DateTime<Local>) -> String {
+        format!(
+            "W/\"{0:x}-{1:x}.{2:x}\"",
+            file.size(),
+            last_modified.timestamp(),
+            last_modified.timestamp_subsec_nanos(),
+        )
+    }
+
+    fn last_modified(last_modified: &DateTime<Local>) -> String {
+        format!(
+            "{} GMT",
+            last_modified
+                .with_timezone(&Utc)
+                .format("%a, %e %b %Y %H:%M:%S")
+        )
+    }
+}
+
+pub async fn make_http_file_response(
+    file: File,
+    cache_control_directive: CacheControlDirective,
+) -> Result<hyper::http::Response<Body>> {
+    let headers = ResponseHeaders::new(&file, cache_control_directive)?;
+    let builder = HttpResponseBuilder::new()
+        .header(http::header::CONTENT_LENGTH, headers.content_length)
+        .header(http::header::CACHE_CONTROL, headers.cache_control)
+        .header(http::header::CONTENT_TYPE, headers.content_type)
+        .header(http::header::ETAG, headers.etag)
+        .header(http::header::LAST_MODIFIED, headers.last_modified);
+
+    let body = file_bytes_into_http_body(file).await;
+    let response = builder
+        .body(body)
+        .context("Failed to build HTTP File Response")?;
+
+    Ok(response)
+}
+
+pub async fn file_bytes_into_http_body(file: File) -> Body {
+    let byte_stream = ByteStream {
+        file: file.file,
+        buffer: Box::new([MaybeUninit::uninit(); FILE_BUFFER_SIZE]),
+    };
+
+    Body::wrap_stream(byte_stream)
+}
+
+pub struct ByteStream {
+    file: tokio::fs::File,
+    buffer: FileBuffer,
+}
+
+impl Stream for ByteStream {
+    type Item = Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        let ByteStream {
+            ref mut file,
+            ref mut buffer,
+        } = *self;
+        let mut read_buffer = ReadBuf::uninit(&mut buffer[..]);
+
+        match Pin::new(file).poll_read(cx, &mut read_buffer) {
+            Poll::Ready(Ok(())) => {
+                let filled = read_buffer.filled();
+
+                if filled.is_empty() {
+                    Poll::Ready(None)
+                } else {
+                    Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
+                }
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Some(Err(error.into()))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/src/addon/static_file/mod.rs
+++ b/src/addon/static_file/mod.rs
@@ -1,0 +1,7 @@
+mod file;
+mod scoped_file_system;
+
+pub mod http;
+
+pub use file::File;
+pub use scoped_file_system::{Directory, Entry, ScopedFileSystem};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod addon;
 mod cli;
 mod config;
 mod server;


### PR DESCRIPTION
Implement static file serving addon

Introduce the Addon concept to write application logic out of the
server implementation itself and aim to a modularized architecture.

Implements a static file serving addon to support sending files to
the client. The static file serving addon also provides a scoped
file system abstraction which securely resolve files in the file system
tree.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
