### PR TITLE
Fix | Remove `ScopedFileSystem` root directory override on "new"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <Empty>
 
+<a name="v0.3.4"></a>
+## v0.3.4 (2021-06-11)
+
+> Requires Rust: rustc 1.52.1 (9bc8c42bb 2021-05-09)
+
+#### Fixes
+
+* Remove the `root` directory path replacement when an empty string or a root
+path (`/`) is provided.
+
 <a name="v0.3.3"></a>
 ## v0.3.3 (2021-06-10)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "http-server"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-server"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 edition = "2018"
 description = "Simple and configurable command-line HTTP server"


### PR DESCRIPTION
Remove the `root` directory path replacement when an empty string or a root
path (`/`) is provided.
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
