### PR TITLE
Feature | File Server | Use 403 "Forbidden" status code for OS Error 5

### DIFF
--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -112,6 +112,10 @@ impl<'a> FileServer {
                     .status(StatusCode::NOT_FOUND)
                     .body(Body::from(err.to_string()))
                     .expect("Failed to build response")),
+                ErrorKind::PermissionDenied => Ok(HttpResponseBuilder::new()
+                    .status(StatusCode::FORBIDDEN)
+                    .body(Body::from(err.to_string()))
+                    .expect("Failed to build response")),
                 _ => Ok(HttpResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(Body::from(err.to_string()))

--- a/src/addon/file_server/scoped_file_system.rs
+++ b/src/addon/file_server/scoped_file_system.rs
@@ -101,10 +101,8 @@ impl ScopedFileSystem {
 
     async fn open(path: PathBuf) -> std::io::Result<Entry> {
         let mut open_options = OpenOptions::new();
-        open_options.read(true);
-
         let entry_path: PathBuf = path.clone();
-        let file = open_options.open(path).await?;
+        let file = open_options.read(true).open(path).await?;
         let metadata = file.metadata().await?;
 
         if metadata.is_dir() {


### PR DESCRIPTION
When opening a file or a directory results in a `PermissionDenied` error, a 403 response must be sent
instead of 500.
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
