### PR TITLE
fix(logger): add missing documentation on logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 <Empty>
 
+<a name="v0.6.0"></a>
+## v0.6.0 (2021-12-30)
+
+> Requires Rust: rustc 1.56.1 (59eed8a2a 2021-11-01)
+
+#### Feature
+
+* Implements logging support using the `--logger` flag.
+* Attach artifacts for Linux, MacOS and Windows on GitHub Releases.
+Kudos to @Emilgardis for openning the issue! [ISSUE#92](https://github.com/EstebanBorai/http-server/issues/92)
+
+#### Fixes
+
+* Update dependencies. Now dependencies are being updated by dependabot every
+monday.
+
+#### Fixes
+
+* Dependencies update
+* Use `release.created` instead of `release.published`
+
 <a name="v0.5.6"></a>
 ## v0.5.6 (2021-10-03)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "http-server"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-server"
-version = "0.5.7"
+version = "0.6.0"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 edition = "2018"
 description = "Simple and configurable command-line HTTP server"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ CORS | Cross-Origin-Resource-Sharing headers support. Refer to [CORS](https://gi
 Compression | GZip compression for HTTP Response Bodies. Refer to [Compression](https://github.com/EstebanBorai/http-server#compression) reference | Disabled
 Verbose | Print server details when running. This doesn't include any logging capabilities. | Disabled
 Basic Authentication | Authorize requests using Basic Authentication. Refer to [Basic Authentication](https://github.com/EstebanBorai/http-server#basic-authentication)  | Disabled
+Logger | Prints HTTP request and response details to stdout | Disabled
 
 ## Usage
 
@@ -73,6 +74,7 @@ Name | Short | Long | Description
 Cross-Origin Resource Sharing | N/A | `--cors` | Enable Cross-Origin Resource Sharing allowing any origin
 GZip Compression | N/A | `--gzip` | Enable GZip compression for responses
 Help | N/A | `--help` | Prints help information
+Logger | N/A | `--logger` | Prints HTTP request and response details to stdout
 Version | `-V` | `--version` | Prints version information
 Verbose | `-v` | `--verbose` | Prints output to console
 


### PR DESCRIPTION
Adds missing documentation on logger.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
