### PR TITLE
Fix suggestion on how to run the server from the tls script

### DIFF
--- a/docs/tls-cert.sh
+++ b/docs/tls-cert.sh
@@ -29,5 +29,5 @@ echo $PWA
 
 echo "Next steps are:"
 echo "Provide your certificate and key to the HTTP Server as follows"
-echo "http-server --tls --tls_cert $PWD/localhost.crt --tls_key $PWD/localhost.pem"
+echo "http-server --tls --tls-cert $PWD/localhost.crt --tls-key $PWD/localhost.key"
 echo "Note: Keep in mind that Certificate installation may differ depending on OS"


### PR DESCRIPTION
The file name of the key has a different extension and the arguments are with dashes.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
