### PR TITLE
feat: parse pem certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
  "local-ip-address",
  "mime_guess",
  "rustls",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "structopt",
@@ -1138,18 +1138,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.0",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ hyper-rustls = { version = "0.23.0", features = ["webpki-roots"] }
 local-ip-address = "0.4.4"
 mime_guess = "2.0.4"
 rustls = "0.20.4"
-rustls-pemfile = "0.3.0"
+rustls-pemfile = "1.0.0"
 termcolor = "1.1.3"
 tokio = { version = "1.18.1", features = ["fs", "rt-multi-thread", "signal", "macros"] }
 tokio-rustls = "0.23.3"

--- a/src/config/util/tls.rs
+++ b/src/config/util/tls.rs
@@ -1,12 +1,9 @@
-use anyhow::{ensure, Context, Error, Result};
-use rustls::internal::msgs::codec::Codec;
-use rustls::Reader;
+use anyhow::{Context, Error, Result};
 use rustls::{Certificate, PrivateKey};
-use rustls_pemfile::{pkcs8_private_keys, rsa_private_keys, Item};
+use rustls_pemfile::{pkcs8_private_keys, rsa_private_keys};
 use serde::Deserialize;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
-use std::iter;
+use std::io::BufReader;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -40,7 +37,6 @@ pub fn load_cert(path: &Path) -> Result<Vec<Certificate>> {
     let mut buf_reader = BufReader::new(file);
     let cert_bytes = &rustls_pemfile::certs(&mut buf_reader).unwrap()[0];
 
-    ensure!(cert_bytes.len() > 0, "Empty certificate");
     Ok(vec![Certificate(cert_bytes.to_vec())])
 }
 
@@ -61,6 +57,5 @@ pub fn load_private_key(path: &Path, kind: &PrivateKeyAlgorithm) -> Result<Priva
         })?,
     };
 
-    ensure!(keys.len() == 1, "Expected a single private key");
     Ok(PrivateKey(keys[0].clone()))
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -105,7 +105,7 @@ impl Server {
             println!("Serving HTTPS: {}", address);
         }
 
-        if let Err(e) = server
+        let server_with_graceful_shutdown = server
             .serve(make_service_fn(|_| {
                 // Move a clone of `handler` into the `service_fn`.
                 let handler = handler.clone();
@@ -116,8 +116,9 @@ impl Server {
                     }))
                 }
             }))
-            .await
-        {
+            .with_graceful_shutdown(crate::utils::signal::shutdown_signal());
+
+        if let Err(e) = server_with_graceful_shutdown.await {
             eprint!("Server Error: {}", e);
         }
     }


### PR DESCRIPTION
Revisits TLS and HTTPS serving. Adds support for PEM files loading.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
