### PR TITLE
fix: improve security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,8 +22,7 @@ hesitate on contacting software editors by opening an issue or a pull request.
 
 ## Reporting a Vulnerability
 
-If you have found any issue using this solution, please don't hesitate to
-open a Pull Request or send an email to estebanborai@gmail.com if you consider
-the issue of urgent priority.
+If you have found any issue using this solution, please don't hesitate to send
+an email to estebanborai@gmail.com.
 
 [1]: https://github.com/EstebanBorai/http-server#tls-https

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,22 +1,29 @@
 # Security Policy
 
-## Supported Versions
+This Command-Line HTTP Server is intended to be as configurable as possible,
+thus security concerns may vary based on the configuration provided on runtime.
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+### Data Security
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.5.x   | :white_check_mark: |
-| 0.4.x   | :x:                |
-| 0.3.x   | :x:                |
-| 0.2.x   | :x:                |
-| 0.1.x   | :x:                |
+If you are running this server to send/receive sensitive data, please make sure
+you configure TLS support and provide a certificate.
+
+Follow on [TLS/HTTPS configuration][1] for more details.
+
+### Host Security
+
+This software is primary written in Rust. Rust is well known for its security
+principles by design, access to invalid memory addresses or invalid references
+are mostly reduced. Even though these warranties many not apply in some
+use cases (those where `unsafe` code is introduced), this software tends to
+avoid the usage of these code blocks. If you find any space for replacement
+of `unsafe` code and you are not sure on how could you apply it, please don't
+hesitate on contacting software editors by opening an issue or a pull request.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+If you have found any issue using this solution, please don't hesitate to
+open a Pull Request or send an email to estebanborai@gmail.com if you consider
+the issue of urgent priority.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+[1]: https://github.com/EstebanBorai/http-server#tls-https


### PR DESCRIPTION
Improves security policy as suggested by [mbartlett21](https://github.com/mbartlett21) on #146.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
