### PR TITLE
fix: replaces spaces with `%20` for filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "lazy_static",
  "local-ip-address",
  "mime_guess",
+ "percent-encoding",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -895,6 +896,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ hyper = { version = "0.14.20", features = ["http1", "server", "stream", "tcp"] }
 hyper-rustls = { version = "0.23.0", features = ["webpki-roots"] }
 local-ip-address = "0.4.5"
 mime_guess = "2.0.4"
+percent-encoding = "2.1.0"
 rustls = "0.20.6"
 rustls-pemfile = "1.0.0"
 serde = { version = "1.0.139", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,13 @@ local-ip-address = "0.4.5"
 mime_guess = "2.0.4"
 rustls = "0.20.6"
 rustls-pemfile = "1.0.0"
+serde = { version = "1.0.139", features = ["derive"] }
+serde_json = "1.0.82"
+structopt = { version = "0.3.26", default-features = false }
 termcolor = "1.1.3"
 tokio = { version = "1.19.2", features = ["fs", "rt-multi-thread", "signal", "macros"] }
 tokio-rustls = "0.23.4"
 toml = "0.5.9"
-serde = { version = "1.0.139", features = ["derive"] }
-serde_json = "1.0.82"
-structopt = { version = "0.3.26", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.3.6", features = ["async_tokio", "html_reports"] }

--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -197,11 +197,9 @@ impl<'a> FileServer {
     /// This happens because links should behave relative to the `/` path
     /// which in this case is `http-server/src` instead of system's root path.
     fn make_dir_entry_link(root_dir: &Path, entry_path: &Path) -> String {
-        let root_dir = root_dir.to_str().unwrap();
-        let entry_path = entry_path.to_str().unwrap();
-        let path_buf = PathBuf::from_str(&entry_path[root_dir.len()..]).unwrap();
+        let path = entry_path.strip_prefix(root_dir).unwrap();
 
-        encode_uri(&path_buf)
+        encode_uri(&path.to_path_buf())
     }
 }
 

--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -199,7 +199,7 @@ impl<'a> FileServer {
     fn make_dir_entry_link(root_dir: &Path, entry_path: &Path) -> String {
         let path = entry_path.strip_prefix(root_dir).unwrap();
 
-        encode_uri(&path.to_path_buf())
+        encode_uri(path)
     }
 }
 

--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -66,7 +66,7 @@ impl<'a> FileServer {
         if let Some(path_and_query) = uri_parts.path_and_query {
             let path = path_and_query.path();
 
-            return decode_uri(path);
+            return Ok(decode_uri(path));
         }
 
         Ok(PathBuf::from_str("/")?)

--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -64,8 +64,9 @@ impl<'a> FileServer {
 
         if let Some(path_and_query) = uri_parts.path_and_query {
             let path = path_and_query.path();
+            let path = path.replace("%20", " ");
 
-            return Ok(PathBuf::from_str(path)?);
+            return Ok(PathBuf::from_str(&path)?);
         }
 
         Ok(PathBuf::from_str("/")?)
@@ -196,11 +197,10 @@ impl<'a> FileServer {
     /// This happens because links should behave relative to the `/` path
     /// which in this case is `http-server/src` instead of system's root path.
     fn make_dir_entry_link(root_dir: &Path, entry_path: &Path) -> String {
-        // format!("/{}", &entry_path[current_dir_path.len()..])
         let root_dir = root_dir.to_str().unwrap();
         let entry_path = entry_path.to_str().unwrap();
 
-        entry_path[root_dir.len()..].to_string()
+        (&entry_path[root_dir.len()..]).replace(" ", "%20")
     }
 }
 
@@ -216,11 +216,11 @@ mod tests {
     fn makes_dir_entry_link() {
         let root_dir = PathBuf::from_str("/Users/bob/sources/http-server").unwrap();
         let entry_path =
-            PathBuf::from_str("/Users/bob/sources/http-server/src/server/service/file_explorer.rs")
+            PathBuf::from_str("/Users/bob/sources/http-server/src/server/service/testing stuff/filename with spaces.txt")
                 .unwrap();
 
         assert_eq!(
-            "/src/server/service/file_explorer.rs",
+            "/src/server/service/testing%20stuff/filename%20with%20spaces.txt",
             FileServer::make_dir_entry_link(&root_dir, &entry_path)
         );
     }

--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::utils::fmt::{format_bytes, format_system_date};
+use crate::utils::url_encode::{decode_uri, encode_uri};
 
 use self::directory_entry::{DirectoryEntry, DirectoryIndex};
 use self::http_utils::{make_http_file_response, CacheControlDirective};
@@ -64,9 +65,8 @@ impl<'a> FileServer {
 
         if let Some(path_and_query) = uri_parts.path_and_query {
             let path = path_and_query.path();
-            let path = path.replace("%20", " ");
 
-            return Ok(PathBuf::from_str(&path)?);
+            return decode_uri(path);
         }
 
         Ok(PathBuf::from_str("/")?)
@@ -199,8 +199,9 @@ impl<'a> FileServer {
     fn make_dir_entry_link(root_dir: &Path, entry_path: &Path) -> String {
         let root_dir = root_dir.to_str().unwrap();
         let entry_path = entry_path.to_str().unwrap();
+        let path_buf = PathBuf::from_str(&entry_path[root_dir.len()..]).unwrap();
 
-        (&entry_path[root_dir.len()..]).replace(" ", "%20")
+        encode_uri(&path_buf)
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod error;
 pub mod fmt;
 pub mod signal;
+pub mod url_encode;

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -8,6 +8,9 @@ use std::str::FromStr;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
+
 pub const PERCENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'-')
     .remove(b'_')

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -15,9 +15,10 @@ pub const PERCENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'~');
 
 pub fn encode_uri(file_path: &PathBuf) -> String {
+    assert!(!file_path.is_absolute());
+
     file_path
         .iter()
-        .filter(|c| c.to_str().unwrap().ne("/"))
         .flat_map(|component| {
             let segment = match component.to_str() {
                 Some(component) => utf8_percent_encode(component, PERCENT_ENCODE_SET),

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -2,9 +2,11 @@ use anyhow::{Error, Result};
 use percent_encoding::{
     percent_decode, percent_encode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC,
 };
-use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::str::FromStr;
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 
 pub const PERCENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'-')

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -1,9 +1,7 @@
-use anyhow::{Error, Result};
 use percent_encoding::{
     percent_decode, percent_encode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC,
 };
-use std::path::{PathBuf, Path};
-use std::str::FromStr;
+use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -54,8 +52,8 @@ pub fn encode_uri(file_path: &Path) -> String {
         .collect::<String>()
 }
 
-pub fn decode_uri(file_path: &str) -> Result<PathBuf> {
-    let path_string = file_path
+pub fn decode_uri(file_path: &str) -> PathBuf {
+    file_path
         .split('/')
         .map(|encoded_part| {
             let decode = percent_decode(encoded_part.as_bytes());
@@ -63,10 +61,7 @@ pub fn decode_uri(file_path: &str) -> Result<PathBuf> {
 
             decode.to_string()
         })
-        .collect::<Vec<String>>()
-        .join("/");
-
-    PathBuf::from_str(&path_string).map_err(|err| Error::msg(err.to_string()))
+        .collect::<PathBuf>()
 }
 
 #[cfg(test)]
@@ -91,7 +86,7 @@ mod tests {
     #[test]
     fn decodes_uri() {
         let file_path = "these%20are%20important%20files/do_not_delete/file%20name.txt";
-        let file_path = decode_uri(&file_path).unwrap();
+        let file_path = decode_uri(&file_path);
         let file_path = file_path.to_str().unwrap();
 
         assert_eq!(

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -1,0 +1,96 @@
+use anyhow::{Error, Result};
+use percent_encoding::{
+    percent_decode, percent_encode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC,
+};
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub const PERCENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+pub fn encode_uri(file_path: &PathBuf) -> String {
+    file_path
+        .iter()
+        .filter(|c| c.to_str().unwrap().ne("/"))
+        .flat_map(|component| {
+            let segment = match component.to_str() {
+                Some(component) => utf8_percent_encode(component, PERCENT_ENCODE_SET),
+                None => {
+                    let bytes = {
+                        #[cfg(windows)]
+                        {
+                            let mut bytes = Vec::with_capacity(component.len() * 2);
+
+                            for wc in component.encode_wide() {
+                                let wc = wc.to_be_bytes();
+
+                                bytes.push(wc[0]);
+                                bytes.push(wc[1]);
+                            }
+
+                            bytes
+                        }
+
+                        #[cfg(not(windows))]
+                        component.as_bytes()
+                    };
+
+                    percent_encode(&bytes, PERCENT_ENCODE_SET)
+                }
+            };
+
+            std::iter::once("/").chain(segment)
+        })
+        .collect::<String>()
+}
+
+pub fn decode_uri(file_path: &str) -> Result<PathBuf> {
+    let path_string = file_path
+        .split('/')
+        .map(|encoded_part| {
+            let decode = percent_decode(encoded_part.as_bytes());
+            let decode = decode.decode_utf8_lossy();
+
+            decode.to_string()
+        })
+        .collect::<Vec<String>>()
+        .join("/");
+
+    PathBuf::from_str(&path_string).map_err(|err| Error::msg(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use super::{decode_uri, encode_uri};
+
+    #[test]
+    fn encodes_uri() {
+        let file_path = "/these are important files/do_not_delete/file name.txt";
+        let file_path = PathBuf::from_str(file_path).unwrap();
+        let file_path = encode_uri(&file_path);
+
+        assert_eq!(
+            file_path,
+            "/these%20are%20important%20files/do_not_delete/file%20name.txt"
+        );
+    }
+
+    #[test]
+    fn decodes_uri() {
+        let file_path = "these%20are%20important%20files/do_not_delete/file%20name.txt";
+        let file_path = decode_uri(&file_path).unwrap();
+        let file_path = file_path.to_str().unwrap();
+
+        assert_eq!(
+            file_path,
+            "these are important files/do_not_delete/file name.txt"
+        );
+    }
+}

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -36,7 +36,7 @@ pub fn encode_uri(file_path: &Path) -> String {
                                 bytes.push(wc[1]);
                             }
 
-                            bytes
+                            &bytes
                         }
 
                         #[cfg(not(windows))]

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -2,7 +2,7 @@ use anyhow::{Error, Result};
 use percent_encoding::{
     percent_decode, percent_encode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC,
 };
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 use std::str::FromStr;
 
 #[cfg(unix)]
@@ -17,7 +17,7 @@ pub const PERCENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'.')
     .remove(b'~');
 
-pub fn encode_uri(file_path: &PathBuf) -> String {
+pub fn encode_uri(file_path: &Path) -> String {
     assert!(!file_path.is_absolute());
 
     file_path
@@ -45,7 +45,7 @@ pub fn encode_uri(file_path: &PathBuf) -> String {
                         component.as_bytes()
                     };
 
-                    percent_encode(&bytes, PERCENT_ENCODE_SET)
+                    percent_encode(bytes, PERCENT_ENCODE_SET)
                 }
             };
 


### PR DESCRIPTION
Replaces spaces with `%20` in order to support filenames with spaces.
The whole request path is not being URL Encoded given that slashes
must remain.

Resolve: https://github.com/EstebanBorai/http-server/issues/163

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
