### PR TITLE
feat: parse request params into `QueryParams`

### DIFF
--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -66,7 +66,7 @@ impl<'a> FileServer {
 
         if let Some(path_and_query) = uri_parts.path_and_query {
             let path = path_and_query.path();
-            let queries = if let Some(query_str) = path_and_query.query() {
+            let _queries = if let Some(query_str) = path_and_query.query() {
                 Some(query_params::QueryParams::from_str(query_str)?)
             } else {
                 None

--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -1,6 +1,7 @@
 mod directory_entry;
 mod file;
 mod http_utils;
+mod query_params;
 mod scoped_file_system;
 
 pub use file::{File, FILE_BUFFER_SIZE};
@@ -59,13 +60,17 @@ impl<'a> FileServer {
         Arc::new(handlebars)
     }
 
-    /// Retrieves the path from the URI and removes the query params
-    fn sanitize_path(req_uri: &str) -> Result<PathBuf> {
+    fn parse_path(req_uri: &str) -> Result<PathBuf> {
         let uri = Uri::from_str(req_uri)?;
         let uri_parts = uri.into_parts();
 
         if let Some(path_and_query) = uri_parts.path_and_query {
             let path = path_and_query.path();
+            let queries = if let Some(query_str) = path_and_query.query() {
+                Some(query_params::QueryParams::from_str(query_str)?)
+            } else {
+                None
+            };
 
             return Ok(decode_uri(path));
         }
@@ -83,8 +88,8 @@ impl<'a> FileServer {
     ///
     /// If the HTTP Request URI points to `/` (root), the default behavior
     /// would be to respond with `Not Found` but in order to provide `root_dir`
-    /// indexing, the request is handled and renders `root_dir` directory listing
-    /// instead.
+    /// indexing, the request is handled and renders `root_dir` directory
+    /// listing instead.
     ///
     /// If the HTTP Request doesn't match any file relative to `root_dir` then
     /// responds with 'Not Found'
@@ -100,7 +105,7 @@ impl<'a> FileServer {
     pub async fn resolve(&self, req_path: String) -> Result<Response<Body>> {
         use std::io::ErrorKind;
 
-        let path = FileServer::sanitize_path(req_path.as_str())?;
+        let path = FileServer::parse_path(req_path.as_str())?;
 
         match self.scoped_file_system.resolve(path).await {
             Ok(entry) => match entry {
@@ -280,7 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_req_uri_path() {
+    fn parse_req_uri_path() {
         let have = vec![
             "/index.html",
             "/index.html?foo=1234",
@@ -296,7 +301,7 @@ mod tests {
         ];
 
         for (idx, req_uri) in have.iter().enumerate() {
-            let sanitized_path = FileServer::sanitize_path(req_uri).unwrap();
+            let sanitized_path = FileServer::parse_path(req_uri).unwrap();
             let wanted_path = PathBuf::from_str(want[idx]).unwrap();
 
             assert_eq!(sanitized_path, wanted_path);

--- a/src/addon/file_server/query_params.rs
+++ b/src/addon/file_server/query_params.rs
@@ -1,0 +1,77 @@
+use anyhow::Error;
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq, Eq)]
+enum SortBy {
+    Name,
+}
+
+impl FromStr for SortBy {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower = s.to_ascii_lowercase();
+        let lower = lower.as_str();
+
+        match lower {
+            "name" => Ok(SortBy::Name),
+            _ => Err(Error::msg("Value doesnt correspond")),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct QueryParams {
+    sort_by: Option<SortBy>,
+}
+
+impl Default for QueryParams {
+    fn default() -> Self {
+        QueryParams { sort_by: None }
+    }
+}
+
+impl FromStr for QueryParams {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut query_params = QueryParams::default();
+
+        for set in s.split('&') {
+            let mut it = set.split('=').take(2);
+
+            if let (Some(key), Some(value)) = (it.next(), it.next()) {
+                match key {
+                    "sort_by" => {
+                        if let Ok(sort_value) = SortBy::from_str(value) {
+                            query_params.sort_by = Some(sort_value);
+                        }
+                    }
+                    _ => continue,
+                }
+            }
+
+            continue;
+        }
+
+        Ok(query_params)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::{QueryParams, SortBy};
+
+    #[test]
+    fn builds_query_params_from_str() {
+        let uri_string = "sort_by=name";
+        let have = QueryParams::from_str(uri_string).unwrap();
+        let expect = QueryParams {
+            sort_by: Some(SortBy::Name),
+        };
+
+        assert_eq!(have, expect);
+    }
+}

--- a/src/addon/file_server/query_params.rs
+++ b/src/addon/file_server/query_params.rs
@@ -20,15 +20,9 @@ impl FromStr for SortBy {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct QueryParams {
     sort_by: Option<SortBy>,
-}
-
-impl Default for QueryParams {
-    fn default() -> Self {
-        QueryParams { sort_by: None }
-    }
 }
 
 impl FromStr for QueryParams {


### PR DESCRIPTION
Introduces support for query parameters parsing into a `QueryParams`
struct. This opens path for enhancements on a more powerful `FileExplorer`.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
