### PR TITLE
feat: resolve with query params

### DIFF
--- a/src/addon/file_server/directory_entry.rs
+++ b/src/addon/file_server/directory_entry.rs
@@ -9,6 +9,7 @@ pub struct DirectoryEntry {
     pub(crate) display_name: String,
     pub(crate) is_dir: bool,
     pub(crate) size: String,
+    pub(crate) len: u64,
     pub(crate) entry_path: String,
     pub(crate) created_at: String,
     pub(crate) updated_at: String,
@@ -67,4 +68,6 @@ pub struct DirectoryIndex {
     /// Directory listing entry
     pub(crate) entries: Vec<DirectoryEntry>,
     pub(crate) breadcrumbs: Vec<BreadcrumbItem>,
+    pub(crate) sort_by_name: bool,
+    pub(crate) sort_by_size: bool,
 }

--- a/src/addon/file_server/query_params.rs
+++ b/src/addon/file_server/query_params.rs
@@ -1,9 +1,11 @@
 use anyhow::Error;
+use serde::Serialize;
 use std::str::FromStr;
 
-#[derive(Debug, PartialEq, Eq)]
-enum SortBy {
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub enum SortBy {
     Name,
+    Size,
 }
 
 impl FromStr for SortBy {
@@ -15,6 +17,7 @@ impl FromStr for SortBy {
 
         match lower {
             "name" => Ok(SortBy::Name),
+            "size" => Ok(SortBy::Size),
             _ => Err(Error::msg("Value doesnt correspond")),
         }
     }
@@ -22,7 +25,7 @@ impl FromStr for SortBy {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct QueryParams {
-    sort_by: Option<SortBy>,
+    pub(crate) sort_by: Option<SortBy>,
 }
 
 impl FromStr for QueryParams {

--- a/src/addon/file_server/scoped_file_system.rs
+++ b/src/addon/file_server/scoped_file_system.rs
@@ -13,7 +13,6 @@ use std::path::{Component, Path, PathBuf};
 use tokio::fs::OpenOptions;
 
 use super::file::File;
-use super::QueryParams;
 
 /// The file is being opened or created for a backup or restore operation.
 /// The system ensures that the calling process overrides file security

--- a/src/addon/file_server/scoped_file_system.rs
+++ b/src/addon/file_server/scoped_file_system.rs
@@ -69,7 +69,10 @@ impl ScopedFileSystem {
     ///
     /// A relative path is built using `build_relative_path` and then is opened
     /// to retrieve a `Entry`.
-    pub async fn resolve(&self, path_and_query: (PathBuf, Option<QueryParams>)) -> std::io::Result<Entry> {
+    pub async fn resolve(
+        &self,
+        path_and_query: (PathBuf, Option<QueryParams>),
+    ) -> std::io::Result<Entry> {
         let entry_path = self.build_relative_path(path_and_query.0);
 
         ScopedFileSystem::open(entry_path).await
@@ -202,7 +205,10 @@ mod tests {
     #[tokio::test]
     async fn resolves_a_file() {
         let sfs = ScopedFileSystem::new(PathBuf::from("")).unwrap();
-        let resolved_entry = sfs.resolve((PathBuf::from("assets/logo.svg"), None)).await.unwrap();
+        let resolved_entry = sfs
+            .resolve((PathBuf::from("assets/logo.svg"), None))
+            .await
+            .unwrap();
 
         if let Entry::File(file) = resolved_entry {
             assert_eq!(file.metadata.is_file(), true);

--- a/src/addon/file_server/scoped_file_system.rs
+++ b/src/addon/file_server/scoped_file_system.rs
@@ -69,11 +69,8 @@ impl ScopedFileSystem {
     ///
     /// A relative path is built using `build_relative_path` and then is opened
     /// to retrieve a `Entry`.
-    pub async fn resolve(
-        &self,
-        path_and_query: (PathBuf, Option<QueryParams>),
-    ) -> std::io::Result<Entry> {
-        let entry_path = self.build_relative_path(path_and_query.0);
+    pub async fn resolve(&self, path: PathBuf) -> std::io::Result<Entry> {
+        let entry_path = self.build_relative_path(path);
 
         ScopedFileSystem::open(entry_path).await
     }
@@ -205,10 +202,7 @@ mod tests {
     #[tokio::test]
     async fn resolves_a_file() {
         let sfs = ScopedFileSystem::new(PathBuf::from("")).unwrap();
-        let resolved_entry = sfs
-            .resolve((PathBuf::from("assets/logo.svg"), None))
-            .await
-            .unwrap();
+        let resolved_entry = sfs.resolve(PathBuf::from("assets/logo.svg")).await.unwrap();
 
         if let Entry::File(file) = resolved_entry {
             assert_eq!(file.metadata.is_file(), true);
@@ -220,7 +214,7 @@ mod tests {
     #[tokio::test]
     async fn detect_directory_paths() {
         let sfs = ScopedFileSystem::new(PathBuf::from("")).unwrap();
-        let resolved_entry = sfs.resolve((PathBuf::from("assets/"), None)).await.unwrap();
+        let resolved_entry = sfs.resolve(PathBuf::from("assets/")).await.unwrap();
 
         assert!(matches!(resolved_entry, Entry::Directory(_)));
     }
@@ -228,7 +222,7 @@ mod tests {
     #[tokio::test]
     async fn detect_directory_paths_without_postfixed_slash() {
         let sfs = ScopedFileSystem::new(PathBuf::from("")).unwrap();
-        let resolved_entry = sfs.resolve((PathBuf::from("assets"), None)).await.unwrap();
+        let resolved_entry = sfs.resolve(PathBuf::from("assets")).await.unwrap();
 
         assert!(matches!(resolved_entry, Entry::Directory(_)));
     }
@@ -237,7 +231,7 @@ mod tests {
     async fn returns_error_if_file_doesnt_exists() {
         let sfs = ScopedFileSystem::new(PathBuf::from("")).unwrap();
         let resolved_entry = sfs
-            .resolve((PathBuf::from("assets/unexistent_file.doc"), None))
+            .resolve(PathBuf::from("assets/unexistent_file.doc"))
             .await;
 
         assert_eq!(resolved_entry.is_err(), true);

--- a/src/addon/file_server/template/explorer.hbs
+++ b/src/addon/file_server/template/explorer.hbs
@@ -28,22 +28,20 @@
       min-width: var(--min-width);
       overflow-y: auto;
       padding: 0;
-      padding-bottom: 2rem;
       width: 95%;
     }
 
     #explorer .hrow {
       background-color: #FFFFFF;
       border-bottom: 1px solid #DDDDDD;
-      position: -webkit-sticky;
-      position: sticky;
-      top: 0;
     }
 
     #explorer .hrow .hcol {
       border-right: 1px solid #DDDDDD;
       box-sizing: border-box;
-      padding: .3rem .35rem;
+      color: #000000;
+      padding: .3rem;
+      text-decoration: none;
     }
 
     #explorer .brow, .bcol {
@@ -65,7 +63,6 @@
 
     #explorer .hcol:nth-child(2), #explorer .bcol:nth-child(2) {
       /* Name Column */
-      overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       width: 300px;
@@ -188,11 +185,19 @@
   <main>
     <ul id="explorer">
       <li class="hrow">
-        <span class="hcol icon-col">&nbsp;</span>
-        <span class="hcol">Name</span>
-        <span class="hcol">Size</span>
-        <span class="hcol">Date created</span>
-        <span class="hcol">Date modified</span>
+        <span class="hcol icon-col"></span>
+        {{#if sort_by_name}}
+          <a class="hcol" href="?sort_by=">Name&nbsp;↓</a>
+        {{else}}
+          <a class="hcol" href="?sort_by=name">Name</a>
+        {{/if}}
+        {{#if sort_by_size}}
+          <a class="hcol" href="?sort_by=">Size&nbsp;↓</a>
+        {{else}}
+          <a class="hcol" href="?sort_by=size">Size</a>
+        {{/if}}
+        <a class="hcol">Date created</a>
+        <a class="hcol">Date modified</a>
       </li>
       {{#each entries}}
       <li class="brow">


### PR DESCRIPTION
Ensures `QueryParams` are included as part of the Request URI parsing,
and passed to File Server resolvers.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
