### PR TITLE
feat: use `l` as short alternative for `logger`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "async-stream"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ harness = false
 dhat-profiling = ["dhat"]
 
 [dependencies]
-anyhow = "1.0.64"
+anyhow = "1.0.65"
 async-stream = "0.3.3"
 async-trait = "0.1.57"
 chrono = "0.4.22"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Cross-Origin Resource Sharing | N/A | `--cors` | Enable Cross-Origin Resource Sh
 GZip Compression | N/A | `--gzip` | Enable GZip compression for responses
 Graceful Shutdown | N/A | `--graceful-shutdown` | Waits for all requests to fulfill before shutting down the server
 Help | N/A | `--help` | Prints help information
-Logger | N/A | `--logger` | Prints HTTP request and response details to stdout
+Logger | `-l` | `--logger` | Prints HTTP request and response details to stdout
 Version | `-V` | `--version` | Prints version information
 Verbose | `-v` | `--verbose` | Prints output to console
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,7 @@ pub struct Cli {
     #[structopt(long = "password")]
     pub password: Option<String>,
     /// Prints HTTP request and response details to stdout
-    #[structopt(long = "logger")]
+    #[structopt(short = "l", long = "logger")]
     pub logger: bool,
     /// Proxy requests to the provided URL
     #[structopt(long = "proxy")]


### PR DESCRIPTION
Provide support for  `l` as short alternative on `logger` 
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
