### PR TITLE
fix: file list overflow

### DIFF
--- a/src/addon/cors.rs
+++ b/src/addon/cors.rs
@@ -296,7 +296,7 @@ mod tests {
                 String::from("Content-Length"),
             ])
         );
-        assert_eq!(cors_config.allow_credentials, false);
+        assert!(!cors_config.allow_credentials);
         assert_eq!(cors_config.max_age, None);
         assert_eq!(cors_config.expose_headers, None);
         assert_eq!(cors_config.request_headers, None);
@@ -327,7 +327,7 @@ mod tests {
                 String::from("Content-Type"),
             ])
         );
-        assert_eq!(cors_config.allow_credentials, false);
+        assert!(!cors_config.allow_credentials);
         assert_eq!(cors_config.max_age, Some(43200));
         assert_eq!(cors_config.expose_headers, None);
         assert_eq!(cors_config.request_headers, None);

--- a/src/addon/file_server/scoped_file_system.rs
+++ b/src/addon/file_server/scoped_file_system.rs
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn normalizes_an_arbitrary_path() {
         let arbitrary_path = PathBuf::from("docs/collegue/cs50/lectures/../code/voting_excecise");
-        let normalized = ScopedFileSystem::normalize_path(&arbitrary_path.clone());
+        let normalized = ScopedFileSystem::normalize_path(&arbitrary_path);
 
         assert_eq!(
             normalized.to_str().unwrap(),
@@ -204,7 +204,7 @@ mod tests {
         let resolved_entry = sfs.resolve(PathBuf::from("assets/logo.svg")).await.unwrap();
 
         if let Entry::File(file) = resolved_entry {
-            assert_eq!(file.metadata.is_file(), true);
+            assert!(file.metadata.is_file());
         } else {
             panic!("Found a directory instead of a file in the provied path");
         }
@@ -233,6 +233,6 @@ mod tests {
             .resolve(PathBuf::from("assets/unexistent_file.doc"))
             .await;
 
-        assert_eq!(resolved_entry.is_err(), true);
+        assert!(resolved_entry.is_err());
     }
 }

--- a/src/addon/file_server/template/explorer.hbs
+++ b/src/addon/file_server/template/explorer.hbs
@@ -24,7 +24,7 @@
       font-family: var(--font);
       font-weight: var(--font-weight);
       margin: 0 auto;
-      max-height: calc(100vh - 2rem);
+      max-height: calc(100vh - 3.3rem);
       min-width: var(--min-width);
       overflow-y: auto;
       padding: 0;

--- a/src/addon/file_server/template/explorer.hbs
+++ b/src/addon/file_server/template/explorer.hbs
@@ -49,6 +49,10 @@
       padding: .15rem 0;
     }
 
+    .bcol {
+      overflow: hidden;
+    }
+
     #explorer .hrow .hcol:first-child,
     #explorer .hrow .hcol:last-child {
       border-right: none;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,7 +126,7 @@ mod tests {
         let mut expect = Cli::default();
 
         expect.host = "192.168.0.1".parse().unwrap();
-        expect.port = 54200 as u16;
+        expect.port = 54200_u16;
 
         assert_eq!(from_args, expect);
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -82,7 +82,7 @@ mod tests {
         let host = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
         let port = 7878;
         let config = ConfigFile::parse_toml(file_contents).unwrap();
-        let mut root_dir = PathBuf::from(std::env::current_dir().unwrap());
+        let mut root_dir = std::env::current_dir().unwrap();
 
         root_dir.push("./fixtures");
 

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn decodes_uri() {
         let file_path = "these%20are%20important%20files/do_not_delete/file%20name.txt";
-        let file_path = decode_uri(&file_path);
+        let file_path = decode_uri(file_path);
         let file_path = file_path.to_str().unwrap();
 
         assert_eq!(


### PR DESCRIPTION
With these changes
* Table cell will not overflow 
![image](https://github.com/http-server-rs/http-server/assets/71790328/dfe29e35-9afa-4c1c-902c-001fa8cb20b3)
* Status bar will not cover up the table behind itself
![image](https://github.com/http-server-rs/http-server/assets/71790328/66d0f5e1-e463-4c54-a84f-b2b2271035af)
