### PR TITLE
feat: replace `--verbose` with `--quiet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ FLAGS:
         --logger               Prints HTTP request and response details to stdout
         --tls                  Enables HTTPS serving using TLS
     -V, --version              Prints version information
-    -v, --verbose              Turns on stdout/stderr logging
+    -q, --quiet              Turns off stdout/stderr logging
 
 OPTIONS:
     -c, --config <config>                          Path to TOML configuration file
@@ -85,7 +85,7 @@ Configuration File | Specifies a configuration file. [Example](https://github.co
 HTTPS (TLS) | HTTPS Secure connection configuration. Refer to [TLS (HTTPS)](https://github.com/http-server-rs/http-server#tls-https) reference | Disabled
 CORS | Cross-Origin-Resource-Sharing headers support. Refer to [CORS](https://github.com/http-server-rs/http-server#cross-origin-resource-sharing-cors) reference | Disabled
 Compression | GZip compression for HTTP Response Bodies. Refer to [Compression](https://github.com/http-server-rs/http-server#compression) reference | Disabled
-Verbose | Print server details when running. This doesn't include any logging capabilities. | Disabled
+Quiet | Don't Print server details when running. This doesn't include any logging capabilities. | Disabled
 Basic Authentication | Authorize requests using Basic Authentication. Refer to [Basic Authentication](https://github.com/http-server-rs/http-server#basic-authentication)  | Disabled
 Logger | Prints HTTP request and response details to stdout | Disabled
 
@@ -111,7 +111,7 @@ Graceful Shutdown | N/A | `--graceful-shutdown` | Wait for all requests to be fu
 Help | N/A | `--help` | Print help information
 Logger | `-l` | `--logger` | Print HTTP request and response details to stdout
 Version | `-V` | `--version` | Print version information
-Verbose | `-v` | `--verbose` | Print output to console
+Quiet | `-q` | `--quiet` | Don't print output to console
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ FLAGS:
         --logger               Prints HTTP request and response details to stdout
         --tls                  Enables HTTPS serving using TLS
     -V, --version              Prints version information
-    -q, --quiet              Turns off stdout/stderr logging
+    -q, --quiet                Turns off stdout/stderr logging
 
 OPTIONS:
     -c, --config <config>                          Path to TOML configuration file

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Configuration File | Specifies a configuration file. [Example](https://github.co
 HTTPS (TLS) | HTTPS Secure connection configuration. Refer to [TLS (HTTPS)](https://github.com/http-server-rs/http-server#tls-https) reference | Disabled
 CORS | Cross-Origin-Resource-Sharing headers support. Refer to [CORS](https://github.com/http-server-rs/http-server#cross-origin-resource-sharing-cors) reference | Disabled
 Compression | GZip compression for HTTP Response Bodies. Refer to [Compression](https://github.com/http-server-rs/http-server#compression) reference | Disabled
-Quiet | Don't Print server details when running. This doesn't include any logging capabilities. | Disabled
+Quiet | Don't print server details when running. This doesn't include any logging capabilities. | Disabled
 Basic Authentication | Authorize requests using Basic Authentication. Refer to [Basic Authentication](https://github.com/http-server-rs/http-server#basic-authentication)  | Disabled
 Logger | Prints HTTP request and response details to stdout | Disabled
 

--- a/fixtures/config.toml
+++ b/fixtures/config.toml
@@ -4,7 +4,7 @@
 host = "127.0.0.1"
 port = 7878
 
-# verbose = false
+# quiet = false
 # root_dir = "./"
 # graceful_shutdown = false
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
-# Use verbose output.
+# Use quiet output.
 # Default: false
-#   verbose = 
+#   quiet = 
 
 # Do not reformat out of line modules.
 # Default: false
@@ -275,4 +275,4 @@
 
 # Replace strings of _ wildcards by a single .. in tuple patterns.
 # Default: false
-#   condense_wildcard_suffices = 
+#   condense_wildcard_suffices =

--- a/src/addon/cors.rs
+++ b/src/addon/cors.rs
@@ -296,7 +296,7 @@ mod tests {
                 String::from("Content-Length"),
             ])
         );
-        assert_eq!(cors_config.allow_credentials, false);
+        assert!(!cors_config.allow_credentials);
         assert_eq!(cors_config.max_age, None);
         assert_eq!(cors_config.expose_headers, None);
         assert_eq!(cors_config.request_headers, None);
@@ -327,7 +327,7 @@ mod tests {
                 String::from("Content-Type"),
             ])
         );
-        assert_eq!(cors_config.allow_credentials, false);
+        assert!(!cors_config.allow_credentials);
         assert_eq!(cors_config.max_age, Some(43200));
         assert_eq!(cors_config.expose_headers, None);
         assert_eq!(cors_config.request_headers, None);

--- a/src/addon/file_server/scoped_file_system.rs
+++ b/src/addon/file_server/scoped_file_system.rs
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn normalizes_an_arbitrary_path() {
         let arbitrary_path = PathBuf::from("docs/collegue/cs50/lectures/../code/voting_excecise");
-        let normalized = ScopedFileSystem::normalize_path(&arbitrary_path.clone());
+        let normalized = ScopedFileSystem::normalize_path(&arbitrary_path);
 
         assert_eq!(
             normalized.to_str().unwrap(),
@@ -204,7 +204,7 @@ mod tests {
         let resolved_entry = sfs.resolve(PathBuf::from("assets/logo.svg")).await.unwrap();
 
         if let Entry::File(file) = resolved_entry {
-            assert_eq!(file.metadata.is_file(), true);
+            assert!(file.metadata.is_file());
         } else {
             panic!("Found a directory instead of a file in the provied path");
         }
@@ -233,6 +233,6 @@ mod tests {
             .resolve(PathBuf::from("assets/unexistent_file.doc"))
             .await;
 
-        assert_eq!(resolved_entry.is_err(), true);
+        assert!(resolved_entry.is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,9 +24,9 @@ pub struct Cli {
     /// Directory to serve files from
     #[structopt(parse(from_os_str), default_value = "./")]
     pub root_dir: PathBuf,
-    /// Turns on stdout/stderr logging
-    #[structopt(short = "v", long = "verbose")]
-    pub verbose: bool,
+    /// Turns off stdout/stderr logging
+    #[structopt(short = "q", long = "quiet")]
+    pub quiet: bool,
     /// Enables HTTPS serving using TLS
     #[structopt(long = "tls")]
     pub tls: bool,
@@ -75,7 +75,7 @@ impl Default for Cli {
             host: "127.0.0.1".parse().unwrap(),
             port: 7878_u16,
             root_dir: PathBuf::from_str("./").unwrap(),
-            verbose: false,
+            quiet: false,
             tls: false,
             tls_cert: PathBuf::from_str("cert.pem").unwrap(),
             tls_key: PathBuf::from_str("key.rsa").unwrap(),
@@ -142,11 +142,11 @@ mod tests {
     }
 
     #[test]
-    fn with_verbose() {
-        let from_args = Cli::from_str_args(vec!["http-server", "--verbose"]);
+    fn with_quiet() {
+        let from_args = Cli::from_str_args(vec!["http-server", "--quiet"]);
         let mut expect = Cli::default();
 
-        expect.verbose = true;
+        expect.quiet = true;
 
         assert_eq!(from_args, expect);
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,7 +126,7 @@ mod tests {
         let mut expect = Cli::default();
 
         expect.host = "192.168.0.1".parse().unwrap();
-        expect.port = 54200 as u16;
+        expect.port = 54200_u16;
 
         assert_eq!(from_args, expect);
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -15,7 +15,7 @@ use super::tls::TlsConfigFile;
 pub struct ConfigFile {
     pub host: IpAddr,
     pub port: u16,
-    pub verbose: Option<bool>,
+    pub quiet: Option<bool>,
     #[serde(default = "current_working_dir")]
     #[serde(deserialize_with = "canonicalize_some")]
     pub root_dir: Option<PathBuf>,
@@ -76,7 +76,7 @@ mod tests {
         let file_contents = r#"
             host = "192.168.0.1"
             port = 7878
-            verbose = true
+            quiet = true
             root_dir = "./fixtures"
         "#;
         let host = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
@@ -91,7 +91,7 @@ mod tests {
         assert!(config.compression.is_none());
         assert_eq!(config.host, host);
         assert_eq!(config.port, port);
-        assert_eq!(config.verbose, Some(true));
+        assert_eq!(config.quiet, Some(true));
         assert_eq!(config.root_dir, Some(root_dir));
     }
 
@@ -111,7 +111,7 @@ mod tests {
         let file_contents = r#"
             host = "192.168.0.1"
             port = 7878
-            verbose = false
+            quiet = false
 
             [tls]
             cert = "cert_123.pem"
@@ -132,7 +132,7 @@ mod tests {
         assert_eq!(config.port, port);
         assert_eq!(config.root_dir, root_dir);
         assert_eq!(config.tls.unwrap(), tls);
-        assert_eq!(config.verbose, Some(false));
+        assert_eq!(config.quiet, Some(false));
     }
 
     #[test]

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -82,7 +82,7 @@ mod tests {
         let host = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
         let port = 7878;
         let config = ConfigFile::parse_toml(file_contents).unwrap();
-        let mut root_dir = PathBuf::from(std::env::current_dir().unwrap());
+        let mut root_dir = std::env::current_dir().unwrap();
 
         root_dir.push("./fixtures");
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,7 +27,7 @@ pub struct Config {
     host: IpAddr,
     port: u16,
     root_dir: PathBuf,
-    verbose: bool,
+    quiet: bool,
     tls: Option<TlsConfig>,
     cors: Option<CorsConfig>,
     compression: Option<CompressionConfig>,
@@ -54,8 +54,8 @@ impl Config {
         self.root_dir.clone()
     }
 
-    pub fn verbose(&self) -> bool {
-        self.verbose
+    pub fn quiet(&self) -> bool {
+        self.quiet
     }
 
     pub fn tls(&self) -> Option<TlsConfig> {
@@ -99,7 +99,7 @@ impl Default for Config {
             port,
             address,
             root_dir,
-            verbose: false,
+            quiet: false,
             tls: None,
             cors: None,
             compression: None,
@@ -115,7 +115,7 @@ impl TryFrom<Cli> for Config {
     type Error = anyhow::Error;
 
     fn try_from(cli_arguments: Cli) -> Result<Self, Self::Error> {
-        let verbose = cli_arguments.verbose;
+        let quiet = cli_arguments.quiet;
         let root_dir = if cli_arguments.root_dir.to_str().unwrap() == "./" {
             current_dir().unwrap()
         } else {
@@ -181,7 +181,7 @@ impl TryFrom<Cli> for Config {
             port: cli_arguments.port,
             address: SocketAddr::new(cli_arguments.host, cli_arguments.port),
             root_dir,
-            verbose,
+            quiet,
             tls,
             cors,
             compression,
@@ -198,7 +198,7 @@ impl TryFrom<ConfigFile> for Config {
 
     fn try_from(file: ConfigFile) -> Result<Self, Self::Error> {
         let root_dir = file.root_dir.unwrap_or_default();
-        let verbose = file.verbose.unwrap_or(false);
+        let quiet = file.quiet.unwrap_or(false);
         let tls: Option<TlsConfig> = if let Some(https_config) = file.tls {
             Some(TlsConfig::new(
                 https_config.cert,
@@ -213,7 +213,7 @@ impl TryFrom<ConfigFile> for Config {
             host: file.host,
             port: file.port,
             address: SocketAddr::new(file.host, file.port),
-            verbose,
+            quiet,
             root_dir,
             tls,
             cors: file.cors,
@@ -249,6 +249,6 @@ mod tests {
             "default socket address: {}",
             address
         );
-        assert!(!config.verbose, "verbose is off by default");
+        assert!(!config.quiet, "quiet is off by default");
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -73,7 +73,7 @@ impl Server {
             }
         }));
 
-        if self.config.verbose() {
+        if !self.config.quiet() {
             println!("Serving HTTP: http://{}", address);
 
             if self.config.address().ip() == Ipv4Addr::from_str("0.0.0.0").unwrap() {
@@ -118,7 +118,7 @@ impl Server {
             }
         }));
 
-        if self.config.verbose() {
+        if !self.config.quiet() {
             println!("Serving HTTPS: http://{}", address);
 
             if self.config.address().ip() == Ipv4Addr::from_str("0.0.0.0").unwrap() {

--- a/src/utils/url_encode.rs
+++ b/src/utils/url_encode.rs
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn decodes_uri() {
         let file_path = "these%20are%20important%20files/do_not_delete/file%20name.txt";
-        let file_path = decode_uri(&file_path);
+        let file_path = decode_uri(file_path);
         let file_path = file_path.to_str().unwrap();
 
         assert_eq!(


### PR DESCRIPTION
Completely replaced verbose with quiet. No trace that the verbose flag ever existed.
I made sure to negate all if statements and sentences referencing the verbose flag.
This is a breaking change: Old configurations containing the verbose flag will no longer work

#362