### PR TITLE
fix: remove all non-automatic clippy warnings

### DIFF
--- a/src/addon/file_server/directory_entry.rs
+++ b/src/addon/file_server/directory_entry.rs
@@ -31,15 +31,7 @@ impl Ord for DirectoryEntry {
 
 impl PartialOrd for DirectoryEntry {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.is_dir && other.is_dir {
-            return Some(self.display_name.cmp(&other.display_name));
-        }
-
-        if self.is_dir && !other.is_dir {
-            return Some(Ordering::Less);
-        }
-
-        Some(Ordering::Greater)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -328,19 +328,15 @@ mod tests {
 
     #[test]
     fn parse_req_uri_path() {
-        let have = vec![
-            "/index.html",
+        let have = ["/index.html",
             "/index.html?foo=1234",
             "/foo/index.html?bar=baz",
-            "/foo/bar/baz.html?day=6&month=27&year=2021",
-        ];
+            "/foo/bar/baz.html?day=6&month=27&year=2021"];
 
-        let want = vec![
-            "/index.html",
+        let want = ["/index.html",
             "/index.html",
             "/foo/index.html",
-            "/foo/bar/baz.html",
-        ];
+            "/foo/bar/baz.html"];
 
         for (idx, req_uri) in have.iter().enumerate() {
             let sanitized_path = FileServer::parse_path(req_uri).unwrap().0;

--- a/src/addon/file_server/mod.rs
+++ b/src/addon/file_server/mod.rs
@@ -328,15 +328,19 @@ mod tests {
 
     #[test]
     fn parse_req_uri_path() {
-        let have = ["/index.html",
+        let have = [
+            "/index.html",
             "/index.html?foo=1234",
             "/foo/index.html?bar=baz",
-            "/foo/bar/baz.html?day=6&month=27&year=2021"];
+            "/foo/bar/baz.html?day=6&month=27&year=2021",
+        ];
 
-        let want = ["/index.html",
+        let want = [
+            "/index.html",
             "/index.html",
             "/foo/index.html",
-            "/foo/bar/baz.html"];
+            "/foo/bar/baz.html",
+        ];
 
         for (idx, req_uri) in have.iter().enumerate() {
             let sanitized_path = FileServer::parse_path(req_uri).unwrap().0;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,7 @@ pub struct Cli {
 
 impl Cli {
     pub fn from_str_args(args: Vec<&str>) -> Self {
-        Cli::from_iter_safe(args.into_iter()).unwrap_or_else(|e| e.exit())
+        Cli::from_iter_safe(args).unwrap_or_else(|e| e.exit())
     }
 }
 
@@ -107,9 +107,10 @@ mod tests {
     #[test]
     fn with_host() {
         let from_args = Cli::from_str_args(vec!["http-server", "--host", "0.0.0.0"]);
-        let mut expect = Cli::default();
-
-        expect.host = "0.0.0.0".parse().unwrap();
+        let expect = Cli {
+            host: "0.0.0.0".parse().unwrap(),
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -123,10 +124,11 @@ mod tests {
             "--port",
             "54200",
         ]);
-        let mut expect = Cli::default();
-
-        expect.host = "192.168.0.1".parse().unwrap();
-        expect.port = 54200_u16;
+        let expect = Cli {
+            host: "192.168.0.1".parse().unwrap(),
+            port: 54200_u16,
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -134,9 +136,10 @@ mod tests {
     #[test]
     fn with_root_dir() {
         let from_args = Cli::from_str_args(vec!["http-server", "~/User/sources/http-server"]);
-        let mut expect = Cli::default();
-
-        expect.root_dir = PathBuf::from_str("~/User/sources/http-server").unwrap();
+        let expect = Cli {
+            root_dir: PathBuf::from_str("~/User/sources/http-server").unwrap(),
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -144,9 +147,10 @@ mod tests {
     #[test]
     fn with_quiet() {
         let from_args = Cli::from_str_args(vec!["http-server", "--quiet"]);
-        let mut expect = Cli::default();
-
-        expect.quiet = true;
+        let expect = Cli {
+            quiet: true,
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -154,9 +158,10 @@ mod tests {
     #[test]
     fn with_tls_no_config() {
         let from_args = Cli::from_str_args(vec!["http-server", "--tls"]);
-        let mut expect = Cli::default();
-
-        expect.tls = true;
+        let expect = Cli {
+            tls: true,
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -173,12 +178,13 @@ mod tests {
             "--tls-key-algorithm",
             "rsa",
         ]);
-        let mut expect = Cli::default();
-
-        expect.tls = true;
-        expect.tls_cert = PathBuf::from_str("~/secrets/cert").unwrap();
-        expect.tls_key = PathBuf::from_str("~/secrets/key").unwrap();
-        expect.tls_key_algorithm = PrivateKeyAlgorithm::Rsa;
+        let expect = Cli {
+            tls: true,
+            tls_cert: PathBuf::from_str("~/secrets/cert").unwrap(),
+            tls_key: PathBuf::from_str("~/secrets/key").unwrap(),
+            tls_key_algorithm: PrivateKeyAlgorithm::Rsa,
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -186,9 +192,10 @@ mod tests {
     #[test]
     fn with_cors() {
         let from_args = Cli::from_str_args(vec!["http-server", "--cors"]);
-        let mut expect = Cli::default();
-
-        expect.cors = true;
+        let expect = Cli {
+            cors: true,
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -196,9 +203,10 @@ mod tests {
     #[test]
     fn with_gzip() {
         let from_args = Cli::from_str_args(vec!["http-server", "--gzip"]);
-        let mut expect = Cli::default();
-
-        expect.gzip = true;
+        let expect = Cli {
+            gzip: true,
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -212,10 +220,11 @@ mod tests {
             "--password",
             "Appleseed",
         ]);
-        let mut expect = Cli::default();
-
-        expect.username = Some(String::from("John"));
-        expect.password = Some(String::from("Appleseed"));
+        let expect = Cli {
+            username: Some(String::from("John")),
+            password: Some(String::from("Appleseed")),
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -223,10 +232,11 @@ mod tests {
     #[test]
     fn with_username_but_not_password() {
         let from_args = Cli::from_str_args(vec!["http-server", "--username", "John"]);
-        let mut expect = Cli::default();
-
-        expect.username = Some(String::from("John"));
-        expect.password = None;
+        let expect = Cli {
+            username: Some(String::from("John")),
+            password: None,
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -234,10 +244,11 @@ mod tests {
     #[test]
     fn with_password_but_not_username() {
         let from_args = Cli::from_str_args(vec!["http-server", "--password", "Appleseed"]);
-        let mut expect = Cli::default();
-
-        expect.username = None;
-        expect.password = Some(String::from("Appleseed"));
+        let expect = Cli {
+            username: None,
+            password: Some(String::from("Appleseed")),
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -245,9 +256,10 @@ mod tests {
     #[test]
     fn with_logger() {
         let from_args = Cli::from_str_args(vec!["http-server", "--logger"]);
-        let mut expect = Cli::default();
-
-        expect.logger = true;
+        let expect = Cli {
+            logger: true,
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }
@@ -255,9 +267,10 @@ mod tests {
     #[test]
     fn with_proxy() {
         let from_args = Cli::from_str_args(vec!["http-server", "--proxy", "https://example.com"]);
-        let mut expect = Cli::default();
-
-        expect.proxy = Some(String::from("https://example.com"));
+        let expect = Cli {
+            proxy: Some(String::from("https://example.com")),
+            ..Default::default()
+        };
 
         assert_eq!(from_args, expect);
     }


### PR DESCRIPTION
Made this into a separate pull request because of the before-mentioned merge conflict possibility

[Reason for the `src/addon/file_server/directory_entry.rs` change](https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_partial_ord_impl_on_ord_type:~:text=If%20both%20PartialOrd%20and%20Ord%20are%20implemented%2C%20they%20must%20agree.%20This%20is%20commonly%20done%20by%20wrapping%20the%20result%20of%20cmp%20in%20Some%20for%20partial_cmp.%20Not%20doing%20this%20may%20silently%20introduce%20an%20error%20upon%20refactoring.)