### PR TITLE
fix: allow http for proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"

--- a/src/addon/proxy.rs
+++ b/src/addon/proxy.rs
@@ -1,10 +1,11 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
 use http::header::USER_AGENT;
 use http::header::{HeaderName, HeaderValue};
 use hyper::client::HttpConnector;
 use hyper::{Body, Client, Response, Uri};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
-use std::str::FromStr;
-use std::sync::Arc;
 
 use crate::server::middleware::Request;
 
@@ -17,7 +18,7 @@ impl Proxy {
     pub fn new(upstream: &str) -> Self {
         let https_connector = HttpsConnectorBuilder::new()
             .with_webpki_roots()
-            .https_only()
+            .https_or_http()
             .enable_http1()
             .build();
         let client = Client::builder().build::<_, hyper::Body>(https_connector);


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Allows HTTP when using `--proxy`.