### PR TITLE
feat: SPA and `index.html` serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 <div align="center">
 
-  [![Crates.io](https://img.shields.io/crates/v/http-server.svg)](https://crates.io/crates/http-server)
-  [![Documentation](https://docs.rs/http-server/badge.svg)](https://docs.rs/http-server)
-  ![Build](https://github.com/http-server-rs/http-server/workflows/build/badge.svg)
-  ![Clippy](https://github.com/http-server-rs/http-server/workflows/clippy/badge.svg)
-  ![Formatter](https://github.com/http-server-rs/http-server/workflows/fmt/badge.svg)
-  ![Tests](https://github.com/http-server-rs/http-server/workflows/test/badge.svg)
-  ![Benchs](https://github.com/http-server-rs/http-server/workflows/bench/badge.svg)
+[![Crates.io](https://img.shields.io/crates/v/http-server.svg)](https://crates.io/crates/http-server)
+[![Documentation](https://docs.rs/http-server/badge.svg)](https://docs.rs/http-server)
+![Build](https://github.com/http-server-rs/http-server/workflows/build/badge.svg)
+![Clippy](https://github.com/http-server-rs/http-server/workflows/clippy/badge.svg)
+![Formatter](https://github.com/http-server-rs/http-server/workflows/fmt/badge.svg)
+![Tests](https://github.com/http-server-rs/http-server/workflows/test/badge.svg)
+![Benches](https://github.com/http-server-rs/http-server/workflows/bench/badge.svg)
 
 </div>
 
@@ -45,10 +45,12 @@ FLAGS:
         --graceful-shutdown    Waits for all requests to fulfill before shutting down the server
         --gzip                 Enable GZip compression for HTTP Responses
         --help                 Prints help information
-        --logger               Prints HTTP request and response details to stdout
-        --tls                  Enables HTTPS serving using TLS
-    -V, --version              Prints version information
+    -l, --logger               Prints HTTP request and response details to stdout
     -q, --quiet                Turns off stdout/stderr logging
+        --spa                  Route non-existent files to /index.html
+        --tls                  Enables HTTPS serving using TLS
+    -i, --index            Route directories to index.html if present
+    -V, --version              Prints version information
 
 OPTIONS:
     -c, --config <config>                          Path to TOML configuration file
@@ -74,19 +76,21 @@ configurations will be used. You can always change this behavior by either
 creating your own config with the [Configuration TOML](https://github.com/http-server-rs/http-server/blob/main/fixtures/config.toml) file
 or by providing CLI arguments described in the [usage](#usage) section.
 
-Name | Description | Default
---- | --- | ---
-Host | Address to bind the server | `127.0.0.1`
-Port | Port to bind the server | `7878`
-Root Directory | The directory to serve files from | `CWD`
-File Explorer UI | A File Explorer UI for the directory configured as the _Root Directory_ | Enabled
-Configuration File | Specifies a configuration file. [Example](https://github.com/http-server-rs/http-server/blob/main/fixtures/config.toml) | Disabled
-HTTPS (TLS) | HTTPS Secure connection configuration. Refer to [TLS (HTTPS)](https://github.com/http-server-rs/http-server#tls-https) reference | Disabled
-CORS | Cross-Origin-Resource-Sharing headers support. Refer to [CORS](https://github.com/http-server-rs/http-server#cross-origin-resource-sharing-cors) reference | Disabled
-Compression | GZip compression for HTTP Response Bodies. Refer to [Compression](https://github.com/http-server-rs/http-server#compression) reference | Disabled
-Quiet | Don't print server details when running. This doesn't include any logging capabilities. | Disabled
-Basic Authentication | Authorize requests using Basic Authentication. Refer to [Basic Authentication](https://github.com/http-server-rs/http-server#basic-authentication)  | Disabled
-Logger | Prints HTTP request and response details to stdout | Disabled
+| Name                 | Description                                                                                                                                                | Default     |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| Host                 | Address to bind the server                                                                                                                                 | `127.0.0.1` |
+| Port                 | Port to bind the server                                                                                                                                    | `7878`      |
+| Root Directory       | The directory to serve files from                                                                                                                          | `CWD`       |
+| File Explorer UI     | A File Explorer UI for the directory configured as the _Root Directory_                                                                                    | Enabled     |
+| Configuration File   | Specifies a configuration file. [Example](https://github.com/http-server-rs/http-server/blob/main/fixtures/config.toml)                                    | Disabled    |
+| HTTPS (TLS)          | HTTPS Secure connection configuration. Refer to [TLS (HTTPS)](https://github.com/http-server-rs/http-server#tls-https) reference                           | Disabled    |
+| CORS                 | Cross-Origin-Resource-Sharing headers support. Refer to [CORS](https://github.com/http-server-rs/http-server#cross-origin-resource-sharing-cors) reference | Disabled    |
+| Compression          | GZip compression for HTTP Response Bodies. Refer to [Compression](https://github.com/http-server-rs/http-server#compression) reference                     | Disabled    |
+| Quiet                | Don't print server details when running. This doesn't include any logging capabilities.                                                                    | Disabled    |
+| Index                | Route directories to index.html if present                                                                                                                 | Disabled    |
+| SPA                  | Route non-existent files to /index.html                                                                                                                    | Disabled    |
+| Basic Authentication | Authorize requests using Basic Authentication. Refer to [Basic Authentication](https://github.com/http-server-rs/http-server#basic-authentication)         | Disabled    |
+| Logger               | Prints HTTP request and response details to stdout                                                                                                         | Disabled    |
 
 ## Usage
 
@@ -102,15 +106,17 @@ Flags are provided without any values. For example:
 http-server --help
 ```
 
-Name | Short | Long | Description
---- | --- | --- | ---
-Cross-Origin Resource Sharing | N/A | `--cors` | Enable Cross-Origin Resource Sharing allowing any origin
-GZip Compression | N/A | `--gzip` | Enable GZip compression for responses
-Graceful Shutdown | N/A | `--graceful-shutdown` | Wait for all requests to be fulfilled before shutting down the server
-Help | N/A | `--help` | Print help information
-Logger | `-l` | `--logger` | Print HTTP request and response details to stdout
-Version | `-V` | `--version` | Print version information
-Quiet | `-q` | `--quiet` | Don't print output to console
+| Name                          | Short | Long                  | Description                                                           |
+| ----------------------------- | ----- | --------------------- | --------------------------------------------------------------------- |
+| Cross-Origin Resource Sharing | N/A   | `--cors`              | Enable Cross-Origin Resource Sharing allowing any origin              |
+| GZip Compression              | N/A   | `--gzip`              | Enable GZip compression for responses                                 |
+| Graceful Shutdown             | N/A   | `--graceful-shutdown` | Wait for all requests to be fulfilled before shutting down the server |
+| Help                          | N/A   | `--help`              | Print help information                                                |
+| Logger                        | `-l`  | `--logger`            | Print HTTP request and response details to stdout                     |
+| Version                       | `-V`  | `--version`           | Print version information                                             |
+| Quiet                         | `-q`  | `--quiet`             | Don't print output to console                                         |
+| Index                         | `-i`  | `--index`             | Route directories to index.html if present                            |
+| SPA                           | N/A   | `--spa`               | Route non-existent files to /index.html                               |
 
 ### Options
 
@@ -120,18 +126,18 @@ Options receive a value and support default values as well.
 http-server --host 127.0.0.1
 ```
 
-Name | Short | Long | Description | Default Value
---- | --- | --- | --- | ---
-Host | `-h` | `--host` | Address to bind the server | `127.0.0.1`
-Port | `-p` | `--port` | Port to bind the server | `7878`
-Configuration File | `-c` | `--config` | Configuration file. [Example](https://github.com/http-server-rs/http-server/blob/main/fixtures/config.toml) | N/A
-TLS | N/A | `--tls` | Enable TLS for HTTPS connections. Requires a Certificate and Key. [Reference](#tls-reference) | N/A
-TLS Ceritificate | N/A | `--tls-cert` | Path to TLS certificate file. **Depends on `--tls`** | `cert.pem`
-TLS Key | N/A | `--tls-key` | Path to TLS key file. **Depends on `--tls`** | `key.rsa`
-TLS Key Algorithm | N/A | `--tls-key-algorithm` | Algorithm used to generate certificate key. **Depends on `--tls`** | `rsa`
-Username | N/A | `--username` | Username to validate using basic authentication | N/A
-Password | N/A | `--password` | Password to validate using basic authentication. **Depends on `--username`** | N/A
-Proxy | N/A | `--proxy` | Proxy requests to the provided URL | N/A
+| Name               | Short | Long                  | Description                                                                                                 | Default Value |
+| ------------------ | ----- | --------------------- | ----------------------------------------------------------------------------------------------------------- | ------------- |
+| Host               | `-h`  | `--host`              | Address to bind the server                                                                                  | `127.0.0.1`   |
+| Port               | `-p`  | `--port`              | Port to bind the server                                                                                     | `7878`        |
+| Configuration File | `-c`  | `--config`            | Configuration file. [Example](https://github.com/http-server-rs/http-server/blob/main/fixtures/config.toml) | N/A           |
+| TLS                | N/A   | `--tls`               | Enable TLS for HTTPS connections. Requires a Certificate and Key. [Reference](#tls-reference)               | N/A           |
+| TLS Certificate    | N/A   | `--tls-cert`          | Path to TLS certificate file. **Depends on `--tls`**                                                        | `cert.pem`    |
+| TLS Key            | N/A   | `--tls-key`           | Path to TLS key file. **Depends on `--tls`**                                                                | `key.rsa`     |
+| TLS Key Algorithm  | N/A   | `--tls-key-algorithm` | Algorithm used to generate certificate key. **Depends on `--tls`**                                          | `rsa`         |
+| Username           | N/A   | `--username`          | Username to validate using basic authentication                                                             | N/A           |
+| Password           | N/A   | `--password`          | Password to validate using basic authentication. **Depends on `--username`**                                | N/A           |
+| Proxy              | N/A   | `--proxy`             | Proxy requests to the provided URL                                                                          | N/A           |
 
 ## Request Handlers
 
@@ -285,7 +291,7 @@ open an issue to be assigned and track the progress there.
 
 - [x] Logging
   - [x] Request/Response Logging
-  - [x] Service Config Loggins
+  - [x] Service Config Logins
 - [ ] File Explorer
   - [x] Modified Date
   - [x] File Size

--- a/fixtures/config.toml
+++ b/fixtures/config.toml
@@ -7,6 +7,8 @@ port = 7878
 # quiet = false
 # root_dir = "./"
 # graceful_shutdown = false
+# index = false
+# spa = false
 
 # [tls]
 # cert = "cert.pem"

--- a/src/addon/file_server/template/error.hbs
+++ b/src/addon/file_server/template/error.hbs
@@ -1,0 +1,4 @@
+<center>
+  <h1>{{code}}</h1>
+  <p>{{error}}</p>
+</center>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,12 @@ pub struct Cli {
     /// Port to bind the server
     #[structopt(short = "p", long = "port", default_value = "7878")]
     pub port: u16,
+    /// Route directories to index.html if present
+    #[structopt(short = "i", long = "index")]
+    pub index: bool,
+    /// Route non-existent files to /index.html
+    #[structopt(long = "spa")]
+    pub spa: bool,
     /// Directory to serve files from
     #[structopt(parse(from_os_str), default_value = "./")]
     pub root_dir: PathBuf,
@@ -74,6 +80,8 @@ impl Default for Cli {
             config: None,
             host: "127.0.0.1".parse().unwrap(),
             port: 7878_u16,
+            index: false,
+            spa: false,
             root_dir: PathBuf::from_str("./").unwrap(),
             quiet: false,
             tls: false,
@@ -145,10 +153,54 @@ mod tests {
     }
 
     #[test]
-    fn with_quiet() {
+    fn with_quiet_long() {
         let from_args = Cli::from_str_args(vec!["http-server", "--quiet"]);
         let expect = Cli {
             quiet: true,
+            ..Default::default()
+        };
+
+        assert_eq!(from_args, expect);
+    }
+
+    #[test]
+    fn with_quiet_short() {
+        let from_args = Cli::from_str_args(vec!["http-server", "-q"]);
+        let expect = Cli {
+            quiet: true,
+            ..Default::default()
+        };
+
+        assert_eq!(from_args, expect);
+    }
+
+    #[test]
+    fn with_spa() {
+        let from_args = Cli::from_str_args(vec!["http-server", "--spa"]);
+        let expect = Cli {
+            spa: true,
+            ..Default::default()
+        };
+
+        assert_eq!(from_args, expect);
+    }
+
+    #[test]
+    fn with_index_long() {
+        let from_args = Cli::from_str_args(vec!["http-server", "--index"]);
+        let expect = Cli {
+            index: true,
+            ..Default::default()
+        };
+
+        assert_eq!(from_args, expect);
+    }
+
+    #[test]
+    fn with_index_short() {
+        let from_args = Cli::from_str_args(vec!["http-server", "-i"]);
+        let expect = Cli {
+            index: true,
             ..Default::default()
         };
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -16,6 +16,8 @@ pub struct ConfigFile {
     pub host: IpAddr,
     pub port: u16,
     pub quiet: Option<bool>,
+    pub index: Option<bool>,
+    pub spa: Option<bool>,
     #[serde(default = "current_working_dir")]
     #[serde(deserialize_with = "canonicalize_some")]
     pub root_dir: Option<PathBuf>,
@@ -78,6 +80,8 @@ mod tests {
             port = 7878
             quiet = true
             root_dir = "./fixtures"
+            index = true
+            spa = true
         "#;
         let host = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
         let port = 7878;
@@ -92,6 +96,8 @@ mod tests {
         assert_eq!(config.host, host);
         assert_eq!(config.port, port);
         assert_eq!(config.quiet, Some(true));
+        assert_eq!(config.index, Some(true));
+        assert_eq!(config.spa, Some(true));
         assert_eq!(config.root_dir, Some(root_dir));
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,6 +26,8 @@ pub struct Config {
     address: SocketAddr,
     host: IpAddr,
     port: u16,
+    index: bool,
+    spa: bool,
     root_dir: PathBuf,
     quiet: bool,
     tls: Option<TlsConfig>,
@@ -44,6 +46,14 @@ impl Config {
 
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    pub fn index(&self) -> bool {
+        self.index
+    }
+
+    pub fn spa(&self) -> bool {
+        self.spa
     }
 
     pub fn address(&self) -> SocketAddr {
@@ -97,6 +107,8 @@ impl Default for Config {
         Self {
             host,
             port,
+            index: false,
+            spa: false,
             address,
             root_dir,
             quiet: false,
@@ -176,10 +188,15 @@ impl TryFrom<Cli> for Config {
             None
         };
 
+        let index = cli_arguments.index;
+        let spa = cli_arguments.spa;
+
         Ok(Config {
             host: cli_arguments.host,
             port: cli_arguments.port,
             address: SocketAddr::new(cli_arguments.host, cli_arguments.port),
+            index,
+            spa,
             root_dir,
             quiet,
             tls,
@@ -208,11 +225,15 @@ impl TryFrom<ConfigFile> for Config {
         } else {
             None
         };
+        let index = file.index.unwrap_or(false);
+        let spa = file.spa.unwrap_or(false);
 
         Ok(Config {
             host: file.host,
             port: file.port,
             address: SocketAddr::new(file.host, file.port),
+            index,
+            spa,
             quiet,
             root_dir,
             tls,

--- a/src/server/handler/mod.rs
+++ b/src/server/handler/mod.rs
@@ -55,7 +55,7 @@ impl From<Arc<Config>> for HttpHandler {
             };
         }
 
-        let file_server = FileServer::new(config.root_dir(), config.clone());
+        let file_server = FileServer::new(config.clone());
         let request_handler = Arc::new(FileServerHandler::new(file_server));
         let middleware = Middleware::try_from(config).unwrap();
         let middleware = Arc::new(middleware);

--- a/src/server/handler/mod.rs
+++ b/src/server/handler/mod.rs
@@ -55,7 +55,7 @@ impl From<Arc<Config>> for HttpHandler {
             };
         }
 
-        let file_server = FileServer::new(config.root_dir());
+        let file_server = FileServer::new(config.root_dir(), config.clone());
         let request_handler = Arc::new(FileServerHandler::new(file_server));
         let middleware = Middleware::try_from(config).unwrap();
         let middleware = Arc::new(middleware);


### PR DESCRIPTION
Copy/pasted every important bit from the previous PR.

Everything looks great except for one small problem: When the `--spa` flag is used, the `--index` flag has to be enabled as well. But the code is really split up into a lot of files and I don't know where I can set `cli.index` to `true` if `cli.spa` is `true` in the code