### PR TITLE
fix(config): `--spa` implies `--index` option

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -188,8 +188,8 @@ impl TryFrom<Cli> for Config {
             None
         };
 
-        let index = cli_arguments.index;
         let spa = cli_arguments.spa;
+        let index = spa || cli_arguments.index;
 
         Ok(Config {
             host: cli_arguments.host,
@@ -225,8 +225,9 @@ impl TryFrom<ConfigFile> for Config {
         } else {
             None
         };
-        let index = file.index.unwrap_or(false);
+
         let spa = file.spa.unwrap_or(false);
+        let index = spa || file.index.unwrap_or(false);
 
         Ok(Config {
             host: file.host,


### PR DESCRIPTION
If #420 there was still an issue that `--spa would work very weirdly without `--index`; single page applications are never implemented without also using `index.html` files. This PR fixes this by automatically setting `cli.index` to `true` if `cli.spa` is set to true.

I could throw an error if the `--index` flag is not passed in with `--spa`, but I think those are way too many keystrokes for a feature someone would already expect

I manually tested this and it works great for every case