### PR TITLE
feat: Switch to color_eyre and remove unneeded .unwrap()s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,6 @@ dependencies = [
  "lazy_static",
  "local-ip-address",
  "mime_guess",
- "pathdiff",
  "percent-encoding",
  "rustls",
  "rustls-pemfile",
@@ -1065,12 +1064,6 @@ dependencies = [
  "smallvec",
  "windows-sys 0.34.0",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,12 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +264,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +452,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -644,10 +675,10 @@ dependencies = [
 name = "http-server"
 version = "0.8.8"
 dependencies = [
- "anyhow",
  "async-stream",
  "async-trait",
  "chrono",
+ "color-eyre",
  "criterion",
  "dhat",
  "flate2",
@@ -661,6 +692,7 @@ dependencies = [
  "lazy_static",
  "local-ip-address",
  "mime_guess",
+ "pathdiff",
  "percent-encoding",
  "rustls",
  "rustls-pemfile",
@@ -755,6 +787,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1000,6 +1038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1065,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.34.0",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -1391,6 +1441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1577,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1696,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1679,6 +1770,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ harness = false
 dhat-profiling = ["dhat"]
 
 [dependencies]
-anyhow = "1.0.75"
 async-stream = "0.3.5"
 async-trait = "0.1.74"
 chrono = { version = "0.4.31", features = ["serde"] }
@@ -58,6 +57,8 @@ tokio = { version = "1.29.1", features = [
 tokio-rustls = "0.23.4"
 toml = "0.7.6"
 humansize = "2.1.3"
+color-eyre = "0.6.2"
+pathdiff = "0.2.1"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ tokio-rustls = "0.23.4"
 toml = "0.7.6"
 humansize = "2.1.3"
 color-eyre = "0.6.2"
-pathdiff = "0.2.1"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }

--- a/src/addon/cors.rs
+++ b/src/addon/cors.rs
@@ -1,6 +1,4 @@
-
 use hyper::header::{self, HeaderName, HeaderValue};
-
 
 use crate::config::cors::CorsConfig;
 
@@ -370,6 +368,6 @@ mod tests {
             request_method: Some(request_method),
         };
 
-        assert_eq!(cors, Cors::try_from(config).unwrap());
+        assert_eq!(cors, Cors::from(config));
     }
 }

--- a/src/addon/cors.rs
+++ b/src/addon/cors.rs
@@ -1,6 +1,6 @@
-use anyhow::{Error, Result};
+
 use hyper::header::{self, HeaderName, HeaderValue};
-use std::convert::TryFrom;
+
 
 use crate::config::cors::CorsConfig;
 
@@ -211,10 +211,8 @@ impl CorsBuilder {
     }
 }
 
-impl TryFrom<CorsConfig> for Cors {
-    type Error = Error;
-
-    fn try_from(value: CorsConfig) -> Result<Self> {
+impl From<CorsConfig> for Cors {
+    fn from(value: CorsConfig) -> Self {
         let mut builder = Cors::builder();
 
         if value.allow_credentials {
@@ -249,7 +247,7 @@ impl TryFrom<CorsConfig> for Cors {
             builder = builder.request_method(request_method);
         }
 
-        Ok(builder.build())
+        builder.build()
     }
 }
 
@@ -341,7 +339,7 @@ mod tests {
             "content-length".to_string(),
             "request-id".to_string(),
         ];
-        let allow_mehtods = vec!["GET".to_string(), "POST".to_string(), "PUT".to_string()];
+        let allow_methods = vec!["GET".to_string(), "POST".to_string(), "PUT".to_string()];
         let allow_origin = String::from("github.com");
         let expose_headers = vec!["content-type".to_string(), "request-id".to_string()];
         let max_age = 5400;
@@ -354,7 +352,7 @@ mod tests {
         let config = CorsConfig {
             allow_credentials: true,
             allow_headers: Some(allow_headers.clone()),
-            allow_methods: Some(allow_mehtods.clone()),
+            allow_methods: Some(allow_methods.clone()),
             allow_origin: Some(allow_origin.clone()),
             expose_headers: Some(expose_headers.clone()),
             max_age: Some(max_age),
@@ -364,7 +362,7 @@ mod tests {
         let cors = Cors {
             allow_credentials: true,
             allow_headers: Some(allow_headers),
-            allow_methods: Some(allow_mehtods),
+            allow_methods: Some(allow_methods),
             allow_origin: Some(allow_origin),
             expose_headers: Some(expose_headers),
             max_age: Some(max_age),

--- a/src/addon/file_server/file.rs
+++ b/src/addon/file_server/file.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context, Result};
 use chrono::{DateTime, Local};
+use color_eyre::eyre::Context;
 use futures::Stream;
 use hyper::body::Bytes;
 use mime_guess::{from_path, Mime};
@@ -40,7 +40,7 @@ impl File {
         self.metadata.len()
     }
 
-    pub fn last_modified(&self) -> Result<DateTime<Local>> {
+    pub fn last_modified(&self) -> color_eyre::Result<DateTime<Local>> {
         let modified = self
             .metadata
             .modified()
@@ -80,7 +80,7 @@ impl From<File> for ByteStream {
 }
 
 impl Stream for ByteStream {
-    type Item = Result<Bytes>;
+    type Item = color_eyre::Result<Bytes>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
         let ByteStream {

--- a/src/addon/file_server/http_utils.rs
+++ b/src/addon/file_server/http_utils.rs
@@ -70,7 +70,9 @@ impl ResponseHeaders {
         file: &File,
         cache_control_directive: CacheControlDirective,
     ) -> color_eyre::Result<ResponseHeaders> {
-        let last_modified = file.last_modified()?;
+        let last_modified = file
+            .last_modified()
+            .context("Unable to get file's last modified date")?;
 
         Ok(ResponseHeaders {
             cache_control: cache_control_directive.to_string(),
@@ -112,7 +114,8 @@ pub async fn make_http_file_response(
     file: File,
     cache_control_directive: CacheControlDirective,
 ) -> color_eyre::Result<hyper::http::Response<Body>> {
-    let headers = ResponseHeaders::new(&file, cache_control_directive)?;
+    let headers = ResponseHeaders::new(&file, cache_control_directive)
+        .context("Failed to construct response headers")?;
     let builder = HttpResponseBuilder::new()
         .header(http::header::CONTENT_LENGTH, headers.content_length)
         .header(http::header::CACHE_CONTROL, headers.cache_control)

--- a/src/addon/file_server/http_utils.rs
+++ b/src/addon/file_server/http_utils.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context, Result};
 use chrono::{DateTime, Local, Utc};
+use color_eyre::eyre::Context;
 use futures::Stream;
 use http::response::Builder as HttpResponseBuilder;
 use hyper::body::Body;
@@ -69,7 +69,7 @@ impl ResponseHeaders {
     pub fn new(
         file: &File,
         cache_control_directive: CacheControlDirective,
-    ) -> Result<ResponseHeaders> {
+    ) -> color_eyre::Result<ResponseHeaders> {
         let last_modified = file.last_modified()?;
 
         Ok(ResponseHeaders {
@@ -111,7 +111,7 @@ impl ResponseHeaders {
 pub async fn make_http_file_response(
     file: File,
     cache_control_directive: CacheControlDirective,
-) -> Result<hyper::http::Response<Body>> {
+) -> color_eyre::Result<hyper::http::Response<Body>> {
     let headers = ResponseHeaders::new(&file, cache_control_directive)?;
     let builder = HttpResponseBuilder::new()
         .header(http::header::CONTENT_LENGTH, headers.content_length)
@@ -143,7 +143,7 @@ pub struct ByteStream {
 }
 
 impl Stream for ByteStream {
-    type Item = Result<Bytes>;
+    type Item = color_eyre::Result<Bytes>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
         let ByteStream {

--- a/src/addon/file_server/query_params.rs
+++ b/src/addon/file_server/query_params.rs
@@ -1,4 +1,4 @@
-use anyhow::Error;
+use color_eyre::eyre::{eyre, Report};
 use serde::Serialize;
 use std::str::FromStr;
 
@@ -11,7 +11,7 @@ pub enum SortBy {
 }
 
 impl FromStr for SortBy {
-    type Err = Error;
+    type Err = Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let lower = s.to_ascii_lowercase();
@@ -22,7 +22,7 @@ impl FromStr for SortBy {
             "size" => Ok(Self::Size),
             "date_created" => Ok(Self::DateCreated),
             "date_modified" => Ok(Self::DateModified),
-            _ => Err(Error::msg("Value doesnt correspond")),
+            _ => Err(eyre!("Value doesn't correspond")),
         }
     }
 }
@@ -33,7 +33,7 @@ pub struct QueryParams {
 }
 
 impl FromStr for QueryParams {
-    type Err = Error;
+    type Err = Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut query_params = QueryParams::default();

--- a/src/addon/file_server/scoped_file_system.rs
+++ b/src/addon/file_server/scoped_file_system.rs
@@ -8,7 +8,6 @@
 //! The `Entry` is a wrapper on OS file system entries such as `File` and
 //! `Directory`. Both `File` and `Directory` are primitive types for
 //! `ScopedFileSystem`
-use anyhow::Result;
 use std::path::{Component, Path, PathBuf};
 use tokio::fs::OpenOptions;
 
@@ -58,8 +57,8 @@ impl ScopedFileSystem {
     /// Creates a new instance of `ScopedFileSystem` using the provided PathBuf
     /// as the root directory to serve files from.
     ///
-    /// Provided paths will resolve relartive to the provided `root` directory.
-    pub fn new(root: PathBuf) -> Result<Self> {
+    /// Provided paths will resolve relative to the provided `root` directory.
+    pub fn new(root: PathBuf) -> color_eyre::Result<Self> {
         Ok(ScopedFileSystem { root })
     }
 

--- a/src/addon/logger.rs
+++ b/src/addon/logger.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use chrono::{DateTime, Utc};
 use http::header::USER_AGENT;
 use http::Method;
@@ -19,7 +18,11 @@ impl Logger {
         Logger { buffer_writer }
     }
 
-    pub async fn log(&mut self, request: Request<Body>, response: Response<Body>) -> Result<()> {
+    pub async fn log(
+        &mut self,
+        request: Request<Body>,
+        response: Response<Body>,
+    ) -> color_eyre::Result<()> {
         let mut buffer = self.buffer_writer.buffer();
         let request = request.lock().await;
         let response = response.lock().await;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -15,10 +15,11 @@ async fn main() -> color_eyre::Result<()> {
 
     color_eyre::install()?;
 
-    make_server()?
+    make_server()
+        .context("Failed to create server")?
         .run()
         .await
-        .context("Failed to make server")?;
+        .context("Error while running server")?;
 
     Ok(())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,5 @@
+use color_eyre::eyre::Context;
 use http_server_lib::make_server;
-use std::process::exit;
 
 #[cfg(feature = "dhat-profiling")]
 use dhat::{Dhat, DhatAlloc};
@@ -9,17 +9,16 @@ use dhat::{Dhat, DhatAlloc};
 static ALLOCATOR: DhatAlloc = DhatAlloc;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> color_eyre::Result<()> {
     #[cfg(feature = "dhat-profiling")]
     let _dhat = Dhat::start_heap_profiling();
 
-    match make_server() {
-        Ok(server) => {
-            server.run().await;
-        }
-        Err(error) => {
-            eprint!("{:?}", error);
-            exit(1);
-        }
-    }
+    color_eyre::install()?;
+
+    make_server()?
+        .run()
+        .await
+        .context("Failed to make server")?;
+
+    Ok(())
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result};
+use color_eyre::eyre::eyre;
 use serde::{Deserialize, Deserializer};
 use std::fs;
 use std::net::IpAddr;
@@ -31,31 +31,28 @@ pub struct ConfigFile {
 }
 
 impl ConfigFile {
-    pub fn from_file(file_path: PathBuf) -> Result<Self> {
+    pub fn from_file(file_path: PathBuf) -> color_eyre::Result<Self> {
         let file = fs::read_to_string(file_path)?;
         let config = ConfigFile::parse_toml(file.as_str())?;
 
         Ok(config)
     }
 
-    fn parse_toml(content: &str) -> Result<Self> {
+    fn parse_toml(content: &str) -> color_eyre::Result<Self> {
         match toml::from_str(content) {
             Ok(config) => Ok(config),
-            Err(err) => Err(Error::msg(format!(
-                "Failed to parse config from file. {}",
-                err
-            ))),
+            Err(err) => Err(eyre!("Failed to parse config from file. {}", err)),
         }
     }
 }
 
-fn canonicalize_some<'de, D>(deserializer: D) -> Result<Option<PathBuf>, D::Error>
+fn canonicalize_some<'de, D>(deserializer: D) -> color_eyre::Result<Option<PathBuf>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let value: &str = Deserialize::deserialize(deserializer)?;
-    let path = PathBuf::from_str(value).unwrap();
-    let canon = fs::canonicalize(path).unwrap();
+    let path = PathBuf::from_str(value).unwrap(); // Unreachable
+    let canon = fs::canonicalize(path).unwrap(); // Unreachable
 
     Ok(Some(canon))
 }
@@ -319,7 +316,7 @@ mod tests {
 
         let proxy = config.proxy.unwrap();
 
-        assert_eq!(proxy.url, "https://example.com");
+        assert_eq!(proxy.uri, "https://example.com");
     }
 
     #[test]

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::eyre;
+use color_eyre::eyre::{eyre, Context};
 use serde::{Deserialize, Deserializer};
 use std::fs;
 use std::net::IpAddr;
@@ -32,8 +32,9 @@ pub struct ConfigFile {
 
 impl ConfigFile {
     pub fn from_file(file_path: PathBuf) -> color_eyre::Result<Self> {
-        let file = fs::read_to_string(file_path)?;
-        let config = ConfigFile::parse_toml(file.as_str())?;
+        let file = fs::read_to_string(file_path).context("Failed to read config file")?;
+        let config =
+            ConfigFile::parse_toml(file.as_str()).context("Failed to parse config file as TOML")?;
 
         Ok(config)
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,8 +6,8 @@ pub mod proxy;
 pub mod tls;
 pub mod util;
 
-use color_eyre::eyre::Context;
-use color_eyre::Report;
+use color_eyre::eyre::{eyre, Context};
+use color_eyre::{Report, Section};
 use http::Uri;
 use std::convert::TryFrom;
 use std::env::current_dir;
@@ -102,6 +102,13 @@ impl TryFrom<Cli> for Config {
         } else {
             None
         };
+
+        // If only one of both is given
+        if cli_arguments.username.is_some() ^ cli_arguments.password.is_some() {
+            return Err(eyre!(
+                "Only one of username or password is given. Expected none or both"
+            ).with_suggestion(|| "Use both the username and password flag.\nExample:\nhttp-server --username YOURUSERNAME --password YOURPASSWORD"));
+        }
 
         let basic_auth: Option<BasicAuthConfig> = if let (Some(username), Some(password)) =
             (cli_arguments.username, cli_arguments.password)

--- a/src/config/proxy.rs
+++ b/src/config/proxy.rs
@@ -1,16 +1,42 @@
-use serde::Deserialize;
+use http::Uri;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProxyConfig {
-    pub url: String,
+    #[serde(with = "uri_serde")]
+    pub uri: Uri,
 }
 
 impl ProxyConfig {
-    pub fn new(url: String) -> Self {
-        ProxyConfig { url }
+    pub fn new(uri: Uri) -> Self {
+        ProxyConfig { uri }
     }
 
-    pub fn url(url: String) -> Self {
-        ProxyConfig { url }
+    pub fn url(uri: Uri) -> Self {
+        ProxyConfig { uri }
+    }
+}
+
+mod uri_serde {
+    use http::uri::InvalidUri;
+    use serde::{de::Error as _, Deserialize, Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<http::Uri, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        let uri = string
+            .parse()
+            .map_err(|err: InvalidUri| D::Error::custom(err.to_string()))?;
+
+        Ok(uri)
+    }
+
+    pub fn serialize<S>(uri: &http::Uri, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&uri.to_string())
     }
 }

--- a/src/config/tls.rs
+++ b/src/config/tls.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use rustls::{Certificate, PrivateKey};
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -26,7 +25,7 @@ impl TlsConfig {
         cert_path: PathBuf,
         key_path: PathBuf,
         key_algorithm: PrivateKeyAlgorithm,
-    ) -> Result<Self> {
+    ) -> color_eyre::Result<Self> {
         let cert = load_cert(&cert_path)?;
         let key = load_private_key(&key_path, &key_algorithm)?;
 

--- a/src/config/tls.rs
+++ b/src/config/tls.rs
@@ -1,3 +1,4 @@
+use color_eyre::eyre::Context;
 use rustls::{Certificate, PrivateKey};
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -26,8 +27,9 @@ impl TlsConfig {
         key_path: PathBuf,
         key_algorithm: PrivateKeyAlgorithm,
     ) -> color_eyre::Result<Self> {
-        let cert = load_cert(&cert_path)?;
-        let key = load_private_key(&key_path, &key_algorithm)?;
+        let cert = load_cert(&cert_path).context("Failed to load certificate")?;
+        let key =
+            load_private_key(&key_path, &key_algorithm).context("Failed to load private key")?;
 
         Ok(TlsConfig {
             cert,

--- a/src/config/util/tls.rs
+++ b/src/config/util/tls.rs
@@ -1,4 +1,7 @@
-use anyhow::{Context, Error, Result};
+use color_eyre::eyre::bail;
+use color_eyre::eyre::eyre;
+use color_eyre::eyre::Context;
+use color_eyre::Report;
 use rustls::{Certificate, PrivateKey};
 use rustls_pemfile::{pkcs8_private_keys, rsa_private_keys};
 use serde::Deserialize;
@@ -16,45 +19,37 @@ pub enum PrivateKeyAlgorithm {
 }
 
 impl FromStr for PrivateKeyAlgorithm {
-    type Err = Error;
+    type Err = Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "rsa" => Ok(PrivateKeyAlgorithm::Rsa),
             "pkcs8" => Ok(PrivateKeyAlgorithm::Pkcs8),
-            _ => anyhow::bail!("Invalid algorithm name provided for TLS key. {}", s),
+            _ => bail!("Invalid algorithm name provided for TLS key. {}", s),
         }
     }
 }
 
 /// Load certificate on the provided `path` and retrieve it
 /// as an instance of `Vec<Certificate>`.
-pub fn load_cert(path: &Path) -> Result<Vec<Certificate>> {
-    let file = File::open(path).context(format!(
-        "Unable to find the TLS certificate on: {}",
-        path.to_str().unwrap()
-    ))?;
+pub fn load_cert(path: &Path) -> color_eyre::Result<Vec<Certificate>> {
+    let file =
+        File::open(path).context(format!("Unable to find the TLS certificate on: {path:?}",))?;
     let mut buf_reader = BufReader::new(file);
-    let cert_bytes = &rustls_pemfile::certs(&mut buf_reader).unwrap()[0];
+    let cert_bytes = &rustls_pemfile::certs(&mut buf_reader)?[0];
 
     Ok(vec![Certificate(cert_bytes.to_vec())])
 }
 
-pub fn load_private_key(path: &Path, kind: &PrivateKeyAlgorithm) -> Result<PrivateKey> {
-    let file = File::open(path)
-        .with_context(|| format!("Unable to find the TLS keys on: {}", path.to_str().unwrap()))?;
+pub fn load_private_key(path: &Path, kind: &PrivateKeyAlgorithm) -> color_eyre::Result<PrivateKey> {
+    let file =
+        File::open(path).with_context(|| format!("Unable to find the TLS keys on: {path:?}"))?;
     let mut reader = BufReader::new(file);
     let keys = match kind {
-        PrivateKeyAlgorithm::Rsa => rsa_private_keys(&mut reader).map_err(|_| {
-            let path = path.to_str().unwrap();
-
-            Error::msg(format!("Failed to read private (RSA) keys at {}", path))
-        })?,
-        PrivateKeyAlgorithm::Pkcs8 => pkcs8_private_keys(&mut reader).map_err(|_| {
-            let path = path.to_str().unwrap();
-
-            Error::msg(format!("Failed to read private (PKCS8) keys at {}", path))
-        })?,
+        PrivateKeyAlgorithm::Rsa => rsa_private_keys(&mut reader)
+            .map_err(|_| eyre!("Failed to read private (RSA) keys at {path:?}"))?,
+        PrivateKeyAlgorithm::Pkcs8 => pkcs8_private_keys(&mut reader)
+            .map_err(|_| eyre!("Failed to read private (PKCS8) keys at {path:?}"))?,
     };
 
     Ok(PrivateKey(keys[0].clone()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod config;
 mod server;
 mod utils;
 
-use anyhow::{Context, Result};
+use color_eyre::eyre::{eyre, Context};
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -12,7 +12,7 @@ use crate::config::file::ConfigFile;
 use crate::config::Config;
 use crate::server::Server;
 
-fn resolve_config(cli_arguments: cli::Cli) -> Result<Config> {
+fn resolve_config(cli_arguments: cli::Cli) -> color_eyre::Result<Config> {
     if let Some(config_path) = cli_arguments.config {
         let config_file = ConfigFile::from_file(config_path)?;
         let config = Config::try_from(config_file)?;
@@ -21,11 +21,10 @@ fn resolve_config(cli_arguments: cli::Cli) -> Result<Config> {
     }
 
     // Otherwise configuration is build from CLI arguments
-    Config::try_from(cli_arguments)
-        .with_context(|| anyhow::Error::msg("Failed to parse arguments from stdin"))
+    Config::try_from(cli_arguments).with_context(|| eyre!("Failed to parse arguments from stdin"))
 }
 
-pub fn make_server() -> Result<Server> {
+pub fn make_server() -> color_eyre::Result<Server> {
     let cli_arguments = cli::Cli::from_args();
     let config = resolve_config(cli_arguments)?;
     let server = Server::new(config);

--- a/src/server/https.rs
+++ b/src/server/https.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use async_stream::stream;
+use color_eyre::eyre::eyre;
 use futures::TryFutureExt;
 use hyper::server::accept::Accept;
 use hyper::server::Builder;
@@ -21,13 +21,13 @@ impl Https {
         Https { cert, key }
     }
 
-    fn make_tls_cfg(&self) -> Result<Arc<ServerConfig>> {
+    fn make_tls_cfg(&self) -> color_eyre::Result<Arc<ServerConfig>> {
         let (certs, private_key) = (self.cert.clone(), self.key.clone());
         let config = ServerConfig::builder()
             .with_safe_defaults()
             .with_no_client_auth()
             .with_single_cert(certs, private_key)
-            .map_err(anyhow::Error::new)?;
+            .map_err(|err| eyre!(err))?;
 
         Ok(Arc::new(config))
     }
@@ -35,7 +35,7 @@ impl Https {
     pub async fn make_server(
         &self,
         addr: SocketAddr,
-    ) -> Result<Builder<impl Accept<Conn = TlsStream<TcpStream>, Error = Error>>> {
+    ) -> color_eyre::Result<Builder<impl Accept<Conn = TlsStream<TcpStream>, Error = Error>>> {
         let tcp = TcpListener::bind(addr).await?;
         let tls_cfg = self.make_tls_cfg()?;
         let tls_acceptor = TlsAcceptor::from(tls_cfg);

--- a/src/server/middleware/cors.rs
+++ b/src/server/middleware/cors.rs
@@ -1,6 +1,6 @@
 use http::{Request, Response};
 use hyper::Body;
-use std::convert::TryFrom;
+
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -24,7 +24,7 @@ use super::MiddlewareAfter;
 ///
 /// Also panics if any CORS header value is not a valid UTF-8 string
 pub fn make_cors_middleware(cors_config: CorsConfig) -> MiddlewareAfter {
-    let cors = Cors::try_from(cors_config).unwrap();
+    let cors = Cors::from(cors_config);
     let cors_headers = cors.make_http_headers();
 
     Box::new(

--- a/src/server/middleware/mod.rs
+++ b/src/server/middleware/mod.rs
@@ -3,7 +3,6 @@ pub mod cors;
 pub mod gzip;
 pub mod logger;
 
-
 use futures::Future;
 use hyper::Body;
 

--- a/src/server/middleware/mod.rs
+++ b/src/server/middleware/mod.rs
@@ -3,10 +3,10 @@ pub mod cors;
 pub mod gzip;
 pub mod logger;
 
-use anyhow::Error;
+
 use futures::Future;
 use hyper::Body;
-use std::convert::TryFrom;
+
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -96,10 +96,8 @@ impl Middleware {
     }
 }
 
-impl TryFrom<Arc<Config>> for Middleware {
-    type Error = Error;
-
-    fn try_from(config: Arc<Config>) -> std::result::Result<Self, Self::Error> {
+impl From<Arc<Config>> for Middleware {
+    fn from(config: Arc<Config>) -> Self {
         let mut middleware = Middleware::default();
 
         if let Some(basic_auth_config) = config.basic_auth.clone() {
@@ -126,6 +124,6 @@ impl TryFrom<Arc<Config>> for Middleware {
             }
         }
 
-        Ok(middleware)
+        middleware
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,7 +4,8 @@ mod service;
 
 pub mod middleware;
 
-use color_eyre::eyre::{bail, Context, Report};
+use color_eyre::eyre::{bail, eyre, Context, Report};
+use color_eyre::Section;
 use hyper::service::{make_service_fn, service_fn};
 use std::net::{Ipv4Addr, SocketAddr};
 
@@ -38,7 +39,12 @@ impl Server {
             index_html.push("index.html");
 
             if !index_html.exists() {
-                bail!("SPA flag is enabled, but index.html in root does not exist");
+                return Err(
+                    eyre!("SPA flag is enabled, but index.html in root does not exist")
+                        .with_suggestion(|| {
+                            format!("Create index.html in root ({:?})", config.root_dir)
+                        }),
+                );
             }
         }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,7 +4,7 @@ mod service;
 
 pub mod middleware;
 
-use color_eyre::eyre::{bail, eyre, Context, Report};
+use color_eyre::eyre::{eyre, Context, Report};
 use color_eyre::Section;
 use hyper::service::{make_service_fn, service_fn};
 use std::net::{Ipv4Addr, SocketAddr};

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -1,9 +1,11 @@
-use anyhow::Result;
 use http::{Request, Response};
 use hyper::Body;
 
 use super::handler::HttpHandler;
 
-pub async fn main_service(handler: HttpHandler, req: Request<Body>) -> Result<Response<Body>> {
+pub async fn main_service(
+    handler: HttpHandler,
+    req: Request<Body>,
+) -> color_eyre::Result<Response<Body>> {
     handler.handle_request(req).await
 }


### PR DESCRIPTION
This PR is a lot. I've completely swapped `anyhow` with `color_eyre`, and replaced most `unwrap`s with `?`. Such changes required changing multiple function signatures and struct fields.

Now, the errors should look way better than they did before.
## Examples
### Before
![image](https://github.com/http-server-rs/http-server/assets/71790328/5ebd7062-7b5d-46eb-b18e-1f5251857028)

### After
![image](https://github.com/http-server-rs/http-server/assets/71790328/4aca8bbd-0e23-49a9-9bf1-c62d3ccdcfed)

### Before
![image](https://github.com/http-server-rs/http-server/assets/71790328/f13c0101-0966-4b41-8c6c-f255fc6bc688)

### After
![image](https://github.com/http-server-rs/http-server/assets/71790328/5fe86003-50b3-4724-8fbc-d52e46c02971)

### Also #425 
![image](https://github.com/http-server-rs/http-server/assets/71790328/010232f2-84fb-4547-a45b-656d93c6979f)
