### PR TITLE
feat: streaming file uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97563d71863fb2824b2e974e754a81d19c4a7ec47b09ced8a0e6656b6d54bd1f"
 dependencies = [
+ "futures-channel",
  "gloo-events",
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1181,7 @@ name = "http-server"
 version = "1.0.0-pre.cfad518"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ version = "1.0.0-pre.cfad518"
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1.83"
+async-stream = "0.3"
 bytes = "1.7.1"
 chrono = "0.4.38"
 clap = "4.5.20"

--- a/src/file-explorer-ui/Cargo.toml
+++ b/src/file-explorer-ui/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/bin/main.rs"
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 gloo = { workspace = true }
-gloo-file = { workspace = true }
+gloo-file = { workspace = true, features = ["futures"] }
 leptos =  { workspace = true, features = ["csr"] }
 leptos_meta = { workspace = true, features = ["csr"] }
 leptos_router = { workspace = true, features = ["csr"] }

--- a/src/file-explorer-ui/src/api/mod.rs
+++ b/src/file-explorer-ui/src/api/mod.rs
@@ -1,9 +1,9 @@
 pub mod proto;
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 use gloo::utils::window;
 use reqwest::{header::CONTENT_TYPE, Url};
-use web_sys::FormData;
+use web_sys::{File, FormData};
 
 use self::proto::DirectoryIndex;
 
@@ -31,8 +31,13 @@ impl Api {
         Ok(index)
     }
 
-    pub async fn upload(&self, form_data: FormData) -> Result<()> {
+    pub async fn upload(&self, file: File) -> Result<()> {
         let url = self.base_url.join("api/v1")?;
+        let form_data = FormData::new()
+            .map_err(|err| Error::msg(format!("Failed to create FormData: {:?}", err)))?;
+        form_data
+            .append_with_blob("file", &file)
+            .map_err(|err| Error::msg(format!("Failed to append file to FormData: {:?}", err)))?;
 
         gloo::net::http::Request::post(url.as_ref())
             .body(form_data)?

--- a/src/file-explorer-ui/src/api/mod.rs
+++ b/src/file-explorer-ui/src/api/mod.rs
@@ -36,23 +36,14 @@ impl Api {
         let reader = gloo_file::futures::read_as_bytes(&file.into()).await?;
 
         let url = self.base_url.join("api/v1")?;
-        let _response = Client::new()
+
+        Client::new()
             .post(url.as_ref())
             .header("Content-Type", "application/octet-stream")
             .header("X-File-Name", file_name)
             .body(reader)
             .send()
             .await?;
-        // let form_data = FormData::new()
-        //     .map_err(|err| Error::msg(format!("Failed to create FormData: {:?}", err)))?;
-        // form_data
-        //     .append_with_blob("file", &file)
-        //     .map_err(|err| Error::msg(format!("Failed to append file to FormData: {:?}", err)))?;
-
-        // gloo::net::http::Request::post(url.as_ref())
-        //     .body(form_data)?
-        //     .send()
-        //     .await?;
 
         Ok(())
     }

--- a/src/file-explorer-ui/src/components/molecules/file_upload.rs
+++ b/src/file-explorer-ui/src/components/molecules/file_upload.rs
@@ -2,7 +2,7 @@ use gloo::utils::window;
 use leptos::logging::log;
 use leptos::wasm_bindgen::JsCast;
 use leptos::{component, create_action, create_node_ref, html, view, IntoView};
-use web_sys::{Event, FormData, HtmlInputElement};
+use web_sys::{Event, HtmlInputElement};
 
 use crate::api::Api;
 use crate::components::atoms::button::Button;
@@ -13,11 +13,8 @@ pub fn FileUpload() -> impl IntoView {
     let upload_file = create_action(|file: &web_sys::File| {
         let file = file.to_owned();
 
-        let form_data = FormData::new().unwrap();
-        form_data.append_with_blob("file", &file).unwrap();
-
         async move {
-            match Api::new().upload(form_data).await {
+            match Api::new().upload(file).await {
                 Ok(_) => {
                     log!("File uploaded successfully");
                     window()

--- a/src/http-server/Cargo.toml
+++ b/src/http-server/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+async-stream = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["env", "derive", "std"] }


### PR DESCRIPTION
This pull request updates the file upload mechanism for the file explorer UI and backend, moving from multipart/form-data uploads to direct binary file uploads with progress tracking. The changes simplify both the frontend and backend code, improve efficiency, and add support for streaming uploads with progress reporting.

**Frontend changes:**

* Migrated from using `FormData` and multipart uploads to sending raw file bytes with the `gloo-file` crate and the `futures` feature enabled. The upload now includes the file name in a custom header (`X-File-Name`). [[1]](diffhunk://#diff-55b48abb0b4f0820e36bb05719560d6943c9725c4424d1dff7d4a195193cb300L21-R21) [[2]](diffhunk://#diff-d38f09cd49a7cf5cf4fa1e90d4ccaade23521476afe3db6ecdab9c32c09b2c08L34-R44) [[3]](diffhunk://#diff-b6621ea043c234fa33a044ab0a57e03bc2eb8c58734e8e318fe93aa61fed43baL16-R17)

**Backend changes:**

* Refactored the upload handler in `FileExplorer` to accept raw binary file streams, extracting the file name from the `X-File-Name` header and writing the stream directly to disk. This replaces the previous multipart parsing logic. [[1]](diffhunk://#diff-bda8049388a5e87160beb69346a09a7ad5d4e0135f06c6e106edf074c637d424R12-R42) [[2]](diffhunk://#diff-bda8049388a5e87160beb69346a09a7ad5d4e0135f06c6e106edf074c637d424L43-R57) [[3]](diffhunk://#diff-bda8049388a5e87160beb69346a09a7ad5d4e0135f06c6e106edf074c637d424L78-R97) [[4]](diffhunk://#diff-bda8049388a5e87160beb69346a09a7ad5d4e0135f06c6e106edf074c637d424L115-R149)
* Added a progress reporting mechanism using a Tokio channel for streaming upload progress and error messages.

**Dependency updates:**

* Added `async-stream` to both workspace and individual crate dependencies to support streaming file uploads. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R28) [[2]](diffhunk://#diff-ca08a7111e0768a675a052f1885b81c4fcc1b51f73cd0ee1a3db671652cf986dR21)

**Other code cleanups:**

* Removed unused imports and code related to multipart/form-data handling in both frontend and backend. [[1]](diffhunk://#diff-b6621ea043c234fa33a044ab0a57e03bc2eb8c58734e8e318fe93aa61fed43baL5-R5) [[2]](diffhunk://#diff-d38f09cd49a7cf5cf4fa1e90d4ccaade23521476afe3db6ecdab9c32c09b2c08L5-R6) [[3]](diffhunk://#diff-bda8049388a5e87160beb69346a09a7ad5d4e0135f06c6e106edf074c637d424L303)
